### PR TITLE
require 'json' to allow using either json/ext or json/pure

### DIFF
--- a/lib/jasmine/base.rb
+++ b/lib/jasmine/base.rb
@@ -1,6 +1,6 @@
 require 'socket'
 require 'erb'
-require 'json/pure'
+require 'json'
 
 module Jasmine
   def self.root


### PR DESCRIPTION
In a project that uses the native json (json/ext) gem the "require 'json/pure'" line in jasmin/base.rb causes all sorts of problems when running tests. I was unable to run cucumber features with the jasmine gem installed alongside the native json gem. 

Changing it to just "require 'json'" appears to allow either the native or the pure json gems to be used depending on which is available.
