### PR TITLE
Rails tasks fix

### DIFF
--- a/generators/jasmine/templates/lib/tasks/jasmine.rake
+++ b/generators/jasmine/templates/lib/tasks/jasmine.rake
@@ -1,2 +1,8 @@
-require 'jasmine'
-load 'jasmine/tasks/jasmine.rake'
+begin
+  require 'jasmine'
+  load 'jasmine/tasks/jasmine.rake'
+rescue LoadError
+  task :jasmine do
+    abort "Jasmine is not available. In order to run jasmine, you must: (sudo) gem install jasmine"
+  end
+end


### PR DESCRIPTION
The generated rake tasks requires jasmine. This forces you to install jasmine-gem and dependencies on the production server to run rake tasks.

This fix just wraps the require in a rescue block, which will prevent rake failing altogether just because the jasmine gem isn't installed.
