### PR TITLE
Add support for remote Selenium RC server

### DIFF
--- a/lib/jasmine/base.rb
+++ b/lib/jasmine/base.rb
@@ -34,9 +34,9 @@ module Jasmine
     true
   end
 
-  def self.wait_for_listener(port, name = "required process", seconds_to_wait = 10)
+  def self.wait_for_listener(host, port, name = "required process", seconds_to_wait = 10)
     time_out_at = Time.now + seconds_to_wait
-    until server_is_listening_on "localhost", port
+    until server_is_listening_on host, port
       sleep 0.1
       puts "Waiting for #{name} on #{port}..."
       raise "#{name} didn't show up on port #{port} after #{seconds_to_wait} seconds." if Time.now > time_out_at

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -276,9 +276,24 @@ describe Jasmine::Config do
   describe "#start_selenium_server" do
     it "should use an existing selenium server if SELENIUM_SERVER_PORT is set" do
       config = Jasmine::Config.new
-      ENV.stub!(:[], "SELENIUM_SERVER_PORT").and_return(1234)
-      Jasmine.should_receive(:wait_for_listener).with(1234, "selenium server")
+      ENV.stub(:[]).with("SELENIUM_SERVER_HOST").and_return(nil)
+      ENV.stub(:[]).with("SELENIUM_SERVER_PORT").and_return(1234)
+      Jasmine.should_receive(:wait_for_listener).with("localhost", 1234, "selenium server")
       config.start_selenium_server
+    end
+    
+    it "should use an existing selenium server if SELENIUM_SERVER_HOST is set" do
+      config = Jasmine::Config.new
+      ENV.stub(:[]).with("SELENIUM_SERVER_HOST").and_return("remote.com")
+      ENV.stub(:[]).with("SELENIUM_SERVER_PORT").and_return(1234)
+      Jasmine.should_receive(:wait_for_listener).with("remote.com", 1234, "selenium server")
+      config.start_selenium_server
+    end
+
+    it "requires SELENIUM_SERVER_PORT if SELENIUM_SERVER_HOST is set" do
+      config = Jasmine::Config.new
+      ENV.stub!(:[], "SELENIUM_SERVER_HOST").and_return("remote.com")
+      expect {config.start_selenium_server}.to raise_error(ArgumentError, "SELENIUM_SERVER_PORT must be defined if SELENIUM_SERVER_HOST is set")
     end
   end
 end


### PR DESCRIPTION
Jasmine currently only supports changing the Selenium server PORT. In an effort to get our CI running Jasmine against IE, we have implemented a new ENV variable (SELENIUM_SERVER_HOST) that allows you to override the host that the selenium client will connect to.

This enables us to run Selenium RC on a Windows box, and have our CI run Jasmine tests against IE.

Ian Zabel & Josh Hawkins
