### PR TITLE
Kill server on SIGINT

### DIFF
--- a/lib/jasmine/tasks/jasmine.rake
+++ b/lib/jasmine/tasks/jasmine.rake
@@ -36,7 +36,11 @@ namespace :jasmine do
     puts "your tests are here:"
     puts "  http://localhost:8888/"
 
-    Jasmine::Config.new.start_server
+    pid = fork do
+      Jasmine::Config.new.start_server
+    end
+    trap("INT"){ Process.kill("KILL", pid) }
+    Process.wait(pid)
   end
 end
 


### PR DESCRIPTION
I hate to find the process id of webrick and kill that un-SIGINT-able process in another console.

Maybe with mongrel installed it works, but if you don't have mongrel it doesn't.

I doesn't test the case in which you have mongrel installed, but it doesn't matter, it kill the process anyway. Maybe a wait of one second will be desirable, but i think it is not necessary for the case.
