### PR TITLE
Run specific spec path from ENV/Config: Alternative 1

### DIFF
--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -15,6 +15,10 @@ module Jasmine
       ENV['SELENIUM_SERVER_PORT'] && ENV['SELENIUM_SERVER_PORT'].to_i > 0 ? ENV['SELENIUM_SERVER_PORT'].to_i : nil
     end
 
+    def jasmine_spec
+      ENV['JASMINE_SPEC']
+    end
+
     def start_server(port = 8888)
       handler = Rack::Handler.default
       handler.run Jasmine.app(self), :Port => port, :AccessLog => []
@@ -65,7 +69,7 @@ module Jasmine
       begin
         start
         puts "servers are listening on their ports -- running the test script..."
-        tests_passed = @client.run
+        tests_passed = @client.run(:spec=>jasmine_spec)
       ensure
         stop
       end

--- a/lib/jasmine/selenium_driver.rb
+++ b/lib/jasmine/selenium_driver.rb
@@ -25,7 +25,12 @@ module Jasmine
       @driver.stop
     end
 
-    def run
+    def run(args={})
+      puts "RUNNING"
+      if args.key?(:spec)
+        @driver.open("/?spec=#{args[:spec].gsub(" ", "%20")}")
+      end
+
       until tests_have_finished? do
         sleep 0.1
       end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -273,6 +273,32 @@ describe Jasmine::Config do
     end
   end
 
+  describe "jasmine spec" do
+    it "should use ENV['JASMINE_SPEC'] if set" do
+      ENV.stub!(:[], "JASMINE_SPEC").and_return("spec path to run")
+      config = Jasmine::Config.new
+      config.stub!(:start_servers)
+      config.stub!(:stop)
+
+      driver = mock(Jasmine::SeleniumDriver, :connect => true)
+      driver.should_receive(:run).with(hash_including(:spec => "spec path to run"))
+
+      Jasmine::SeleniumDriver.should_receive(:new).
+              and_return(driver)
+      config.run
+    end
+
+    it "should append specs to the url" do
+      driver = mock(Selenium::Client::Driver, :get_eval => "true")
+      driver.should_receive(:open).with("/?spec=spec%20to%20run")
+      Selenium::Client::Driver.should_receive(:new).
+        and_return(driver)
+
+      Jasmine::SeleniumDriver.new("localhost", 9999, "*chrome", "http://localhost:9999").
+        run(:spec => "spec to run")
+    end
+  end
+
   describe "#start_selenium_server" do
     it "should use an existing selenium server if SELENIUM_SERVER_PORT is set" do
       config = Jasmine::Config.new


### PR DESCRIPTION
This is alternative 1 for running specific specs from jasmine:ci using ENV, config, and run(), which seems that no one uses. Another alternative is in another pull request.
