### PR TITLE
Run specific spec path from ENV/Config: Alternative 2

### DIFF
--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -11,6 +11,10 @@ module Jasmine
       ENV["JASMINE_HOST"] || 'http://localhost'
     end
 
+    def jasmine_spec
+      ENV['JASMINE_SPEC']
+    end
+
     def external_selenium_server_port
       ENV['SELENIUM_SERVER_PORT'] && ENV['SELENIUM_SERVER_PORT'].to_i > 0 ? ENV['SELENIUM_SERVER_PORT'].to_i : nil
     end
@@ -23,7 +27,7 @@ module Jasmine
     def start
       start_servers
       @client = Jasmine::SeleniumDriver.new("localhost", @selenium_server_port, "*#{browser}", "#{jasmine_host}:#{@jasmine_server_port}/")
-      @client.connect
+      @client.connect(:spec => jasmine_spec)
     end
 
     def stop

--- a/lib/jasmine/selenium_driver.rb
+++ b/lib/jasmine/selenium_driver.rb
@@ -16,9 +16,11 @@ module Jasmine
       @driver.get_eval("window.jasmine.getEnv().currentRunner.finished") == "true"
     end
 
-    def connect
+    def connect(args={})
+      spec = args[:spec] || ""
+      url = spec.empty? ? "/" : "/?spec=" + spec.gsub(" ", "%20")
       @driver.start
-      @driver.open("/")
+      @driver.open(url)
     end
 
     def disconnect

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -273,6 +273,31 @@ describe Jasmine::Config do
     end
   end
 
+  describe "jasmine spec" do
+    it "should use ENV['JASMINE_SPEC'] if set" do
+      ENV.stub!(:[], "JASMINE_SPEC").and_return("spec path to run")
+      config = Jasmine::Config.new
+      config.stub!(:start_servers)
+
+      driver = mock(Jasmine::SeleniumDriver)
+      driver.should_receive(:connect).with(hash_including(:spec => "spec path to run"))
+
+      Jasmine::SeleniumDriver.should_receive(:new).
+        and_return(driver)
+      config.start
+    end
+
+    it "should append specs to the url" do
+      driver = mock(Selenium::Client::Driver, :start => true,  :get_eval => "true")
+      driver.should_receive(:open).with("/?spec=spec%20to%20run")
+      Selenium::Client::Driver.should_receive(:new).
+        and_return(driver)
+
+      Jasmine::SeleniumDriver.new("localhost", 9999, "*chrome", "http://localhost:9999").
+        connect(:spec => "spec to run")
+    end
+  end
+
   describe "#start_selenium_server" do
     it "should use an existing selenium server if SELENIUM_SERVER_PORT is set" do
       config = Jasmine::Config.new


### PR DESCRIPTION
Run specific spec path from jasmine:ci using ENV/Config/Driver start()

This ia alternative to my other pull request. Since no existing code appears to use run any more, I modified Config.start -> Driver.connect to take args, and alter the url to include ?spec=JASMINE_SPEC

In either case, while the code works and selenium runs just one spec, the rspec reports still list all specs as tested/passed. It appears that jasmine html report listed all specs as "passed", even though the ui lists 1 passed, 0 failed. I would expect JsApiReporter to repo those skipped specs as "skipped". (Bug filed elsewhere).
