### PR TITLE
Fix rake task for Ruby 1.9

### DIFF
--- a/lib/jasmine/tasks/jasmine.rake
+++ b/lib/jasmine/tasks/jasmine.rake
@@ -31,7 +31,10 @@ namespace :jasmine do
 
   task :server => "jasmine:require" do
     jasmine_config_overrides = 'spec/javascripts/support/jasmine_config.rb'
-    require jasmine_config_overrides if File.exist?(jasmine_config_overrides)
+
+    if File.exist?(jasmine_config_overrides)
+      require File.join(Rails.root, jasmine_config_overrides) 
+    end
 
     puts "your tests are here:"
     puts "  http://localhost:8888/"


### PR DESCRIPTION
If jasmine_config.rb is present, it doesn't load correctly under Ruby 1.9 when using the jasmine rake task.

This commit fixes it.
