### PR TITLE
read alternative path to 'jasmine.yml' file from ENV.CONFIG_YML

### DIFF
--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -104,7 +104,19 @@ module Jasmine
     end
 
     def simple_config_file
-      File.join(project_root, 'spec/javascripts/support/jasmine.yml')
+      envConfig = ENV["CONFIG_YML"]
+      defaultConfigFile = File.join(project_root, 'spec/javascripts/support/jasmine.yml')
+      if envConfig
+        if File.exist?(File.join(project_root, envConfig ))
+          File.join(project_root, envConfig)
+        elsif File.exist?(File.join(project_root, 'spec/javascripts/support', envConfig))
+          File.join(project_root, 'spec/javascripts/support', envConfig)
+        else
+          defaultConfigFile
+        end
+      else
+        defaultConfigFile
+      end
     end
 
     def src_dir


### PR DESCRIPTION
patch for issue "support multiple config file" https://github.com/pivotal/jasmine/issues/27

for example, if you want to test only some project part and don't want to include all project sources,
you can describe required js files at another yml config and run:
rake jasmine CONFIG_YML=subproject_name/jasmine_subproject.yml

It tries to find file project_root/CONFIG_YML  (project_root/subproject_name/jasmine_subproject.yml). 
If there is no such file, it tries to find it at 'spec/javascripts/support' (project_root/spec/javascripts/support/subproject_name/jasmine_subproject.yml).
And it uses default project_root/spec/javascripts/support/jasmine.yml file if CONFIG_YML is not defined or such file was not found.
