### PR TITLE
Support for custom root paths and nonstandard source paths

### DIFF
--- a/generators/jasmine/templates/jasmine-example/spec/SpecHelper.js
+++ b/generators/jasmine/templates/jasmine-example/spec/SpecHelper.js
@@ -2,8 +2,8 @@ beforeEach(function() {
   this.addMatchers({
     toBePlaying: function(expectedSong) {
       var player = this.actual;
-      return player.currentlyPlayingSong === expectedSong
-          && player.isPlaying;
+      return player.currentlyPlayingSong === expectedSong && 
+             player.isPlaying;
     }
-  })
+  });
 });

--- a/generators/jasmine/templates/spec/javascripts/support/jasmine-rails.yml
+++ b/generators/jasmine/templates/spec/javascripts/support/jasmine-rails.yml
@@ -79,3 +79,14 @@ src_dir:
 # spec_dir: spec/javascripts
 #
 spec_dir: spec/javascripts
+
+# root_dir
+#
+# Root directory path. Files in this directory will be mounted in the web server's root ("/") path.
+# Default: project root
+# 
+# EXAMPLE:
+# 
+# root_dir: public
+#
+root_dir:

--- a/generators/jasmine/templates/spec/javascripts/support/jasmine.yml
+++ b/generators/jasmine/templates/spec/javascripts/support/jasmine.yml
@@ -71,3 +71,14 @@ src_dir:
 # spec_dir: spec/javascripts
 #
 spec_dir:
+
+# root_dir
+#
+# Root directory path. Files in this directory will be mounted in the web server's root ("/") path.
+# Default: project root
+# 
+# EXAMPLE:
+# 
+# root_dir: public
+#
+root_dir:

--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -89,7 +89,7 @@ module Jasmine
     def root_path
       "/__root__"
     end
-
+    
     def js_files(spec_filter = nil)
       spec_files_to_include = spec_filter.nil? ? spec_files : match_files(spec_dir, [spec_filter])
       src_files.collect {|f| "/" + f } + helpers.collect {|f| File.join(spec_path, f) } + spec_files_to_include.collect {|f| File.join(spec_path, f) }
@@ -137,9 +137,17 @@ module Jasmine
 
     def src_files
       if simple_config['src_files']
-        match_files(src_dir, simple_config['src_files'])
+        match_files(src_dir, simple_config['src_files']).collect { |f| File.join("__src__", f) }
       else
         []
+      end
+    end
+    
+    def root_dir
+      if simple_config['root_dir']
+        File.join(project_root, simple_config['root_dir'])
+      else
+        project_root
       end
     end
 

--- a/lib/jasmine/server.rb
+++ b/lib/jasmine/server.rb
@@ -85,9 +85,12 @@ module Jasmine
       map(config.spec_path)    { run Rack::File.new(config.spec_dir) }
       map(config.root_path)    { run Rack::File.new(config.project_root) }
 
-      map('/') do
+      map '/' do
         run Rack::Cascade.new([
-          Rack::URLMap.new('/' => Rack::File.new(config.src_dir)),
+          Rack::URLMap.new(
+            '/' => Rack::File.new(config.root_dir),
+            '/__src__' => Rack::File.new(config.src_dir)
+            ),
           Jasmine::RunAdapter.new(config)
         ])
       end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -48,7 +48,7 @@ describe Jasmine::Config do
         end
 
         it "should find the source files" do
-          @config.src_files.should =~ ['public/javascripts/Player.js', 'public/javascripts/Song.js']
+          @config.src_files.should =~ ['__src__/public/javascripts/Player.js', '__src__/public/javascripts/Song.js']
         end
 
         it "should find the stylesheet files" do
@@ -65,8 +65,8 @@ describe Jasmine::Config do
 
         it "should build an array of all the JavaScript files to include, source files then spec files" do
           @config.js_files.should == [
-                  '/public/javascripts/Player.js',
-                  '/public/javascripts/Song.js',
+                  '/__src__/public/javascripts/Player.js',
+                  '/__src__/public/javascripts/Song.js',
                   '/__spec__/helpers/SpecHelper.js',
                   '/__spec__/PlayerSpec.js'
           ]
@@ -74,8 +74,8 @@ describe Jasmine::Config do
 
         it "should allow the js_files to be filtered" do
           @config.js_files("PlayerSpec.js").should == [
-                  '/public/javascripts/Player.js',
-                  '/public/javascripts/Song.js',
+                  '/__src__/public/javascripts/Player.js',
+                  '/__src__/public/javascripts/Song.js',
                   '/__spec__/helpers/SpecHelper.js',
                   '/__spec__/PlayerSpec.js'
           ]
@@ -89,7 +89,7 @@ describe Jasmine::Config do
       it "should parse ERB" do
         @config.stub!(:simple_config_file).and_return(File.expand_path(File.join(@root, 'spec', 'fixture','jasmine.erb.yml')))
         Dir.stub!(:glob).and_return { |glob_string| [glob_string] }
-        @config.src_files.should == ['file0.js', 'file1.js', 'file2.js',]
+        @config.src_files.should == ['__src__/file0.js', '__src__/file1.js', '__src__/file2.js',]
       end
 
       describe "if jasmine.yml not found" do
@@ -130,7 +130,7 @@ describe Jasmine::Config do
         end
 
         it "src_files" do
-          @config.src_files.should == ['file1.ext', 'file2.ext']
+          @config.src_files.should == ['__src__/file1.ext', '__src__/file2.ext']
         end
 
         it "stylesheets" do
@@ -146,8 +146,8 @@ describe Jasmine::Config do
         end
 
         it "js_files" do
-          @config.js_files.should == ["/file1.ext",
-                                      "/file2.ext",
+          @config.js_files.should == ["/__src__/file1.ext",
+                                      "/__src__/file2.ext",
                                       "/__spec__/file1.ext",
                                       "/__spec__/file2.ext",
                                       "/__spec__/file1.ext",
@@ -170,7 +170,7 @@ describe Jasmine::Config do
         end
 
         it "should not contain negated files" do
-          @config.src_files.should == ["file2.ext"]
+          @config.src_files.should == ["__src__/file2.ext"]
         end
       end
 
@@ -194,32 +194,32 @@ describe Jasmine::Config do
 
         @config.spec_files.should == ['PlayerSpec.js']
         @config.helpers.should == ['helpers/SpecHelper.js']
-        @config.src_files.should == ['public/javascripts/prototype.js',
-                                     'public/javascripts/effects.js',
-                                     'public/javascripts/controls.js',
-                                     'public/javascripts/dragdrop.js',
-                                     'public/javascripts/application.js',
-                                     'public/javascripts/Player.js',
-                                     'public/javascripts/Song.js']
+        @config.src_files.should == ['__src__/public/javascripts/prototype.js',
+                                     '__src__/public/javascripts/effects.js',
+                                     '__src__/public/javascripts/controls.js',
+                                     '__src__/public/javascripts/dragdrop.js',
+                                     '__src__/public/javascripts/application.js',
+                                     '__src__/public/javascripts/Player.js',
+                                     '__src__/public/javascripts/Song.js']
         @config.js_files.should == [
-                '/public/javascripts/prototype.js',
-                '/public/javascripts/effects.js',
-                '/public/javascripts/controls.js',
-                '/public/javascripts/dragdrop.js',
-                '/public/javascripts/application.js',
-                '/public/javascripts/Player.js',
-                '/public/javascripts/Song.js',
+                '/__src__/public/javascripts/prototype.js',
+                '/__src__/public/javascripts/effects.js',
+                '/__src__/public/javascripts/controls.js',
+                '/__src__/public/javascripts/dragdrop.js',
+                '/__src__/public/javascripts/application.js',
+                '/__src__/public/javascripts/Player.js',
+                '/__src__/public/javascripts/Song.js',
                 '/__spec__/helpers/SpecHelper.js',
                 '/__spec__/PlayerSpec.js',
         ]
         @config.js_files("PlayerSpec.js").should == [
-                '/public/javascripts/prototype.js',
-                '/public/javascripts/effects.js',
-                '/public/javascripts/controls.js',
-                '/public/javascripts/dragdrop.js',
-                '/public/javascripts/application.js',
-                '/public/javascripts/Player.js',
-                '/public/javascripts/Song.js',
+                '/__src__/public/javascripts/prototype.js',
+                '/__src__/public/javascripts/effects.js',
+                '/__src__/public/javascripts/controls.js',
+                '/__src__/public/javascripts/dragdrop.js',
+                '/__src__/public/javascripts/application.js',
+                '/__src__/public/javascripts/Player.js',
+                '/__src__/public/javascripts/Song.js',
                 '/__spec__/helpers/SpecHelper.js',
                 '/__spec__/PlayerSpec.js'
         ]

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -7,6 +7,7 @@ describe "Jasmine.app" do
   def app
     config = Jasmine::Config.new
     config.stub!(:project_root).and_return(Jasmine.root)
+    config.stub!(:root_dir).and_return(File.join(Jasmine.root, "example"))
     config.stub!(:spec_dir).and_return(File.join(Jasmine.root, "spec"))
     config.stub!(:src_dir).and_return(File.join(Jasmine.root, "src"))
     config.stub!(:src_files).and_return(["file1.js"])
@@ -21,15 +22,22 @@ describe "Jasmine.app" do
     last_response.body.should == File.read(File.join(Jasmine.root, "spec/suites/EnvSpec.js"))
     end
 
-  it "should serve static files from root dir under __root__" do
+  it "should serve static files from project dir under __root__" do
     get "/__root__/src/base.js"
     last_response.status.should == 200
     last_response.content_type.should == "application/javascript"
     last_response.body.should == File.read(File.join(Jasmine.root, "src/base.js"))
   end
-
-  it "should serve static files from src dir under /" do
-    get "/base.js"
+  
+  it "should serve static files from root dir under /" do
+    get "/SpecRunner.html"
+    last_response.status.should == 200
+    last_response.content_type.should == "text/html"
+    last_response.body.should == File.read(File.join(Jasmine.root, "example/SpecRunner.html"))
+  end
+  
+  it "should serve static files from src dir under __src__" do
+    get "/__src__/base.js"
     last_response.status.should == 200
     last_response.content_type.should == "application/javascript"
     last_response.body.should == File.read(File.join(Jasmine.root, "src/base.js"))


### PR DESCRIPTION
Some applications may store JS source files in a directory other than `public/` while still requiring assets from `public/` to be treated as if they were in the Web app's root directory.

Source files need a way to reference, e.g., `/images/bullet.png` instead of `/public/images/bullet.png` because, once deployed, the _public_ node disappears from the path entirely.

My pull request addresses this issue by allowing the user to specify in `jasmine.yml` an optional _root_dir_. Additionally, source files are placed in the `/__src__` path to avoid conflicts.

Since the actual URL paths are largely generated by Jasmine, I don't think this will break any existing apps out there. Since they don't have a root path in their `jasmine.yml`, it will default to the project directory and everything will Just Work.

All specs for this pull request are green for me, for each of pojs-rspec1; pojs-rspec2; rails2; rails3.
