### PR TITLE
Fix init command when a Rakefile is already present

### DIFF
--- a/lib/jasmine/command_line_tool.rb
+++ b/lib/jasmine/command_line_tool.rb
@@ -44,13 +44,13 @@ module Jasmine
           copy_unless_exists('spec/javascripts/support/jasmine-rails.yml', 'spec/javascripts/support/jasmine.yml')
         else
           copy_unless_exists('spec/javascripts/support/jasmine.yml')
+          require 'rake'
           write_mode = 'w'
           if File.exist?(dest_path('Rakefile'))
             load dest_path('Rakefile')
             write_mode = 'a'
           end
 
-          require 'rake'
           unless Rake::Task.task_defined?('jasmine')
             File.open(dest_path('Rakefile'), write_mode) do |f|
               f.write("\n" + File.read(template_path('lib/tasks/jasmine.rake')))

--- a/spec/fixture/Rakefile
+++ b/spec/fixture/Rakefile
@@ -1,0 +1,4 @@
+desc "A flunk task that does not want to be trampled"
+task :jasmine_flunk do
+  nil
+end

--- a/spec/jasmine_command_line_tool_rakeless_spec.rb
+++ b/spec/jasmine_command_line_tool_rakeless_spec.rb
@@ -1,0 +1,20 @@
+require File.expand_path(File.join(File.dirname(__FILE__), "spec_helper"))
+
+describe "Jasmine command line tool" do
+  context "when rake has not been required yet" do
+    before :each do
+      temp_dir_before
+      Dir::chdir @tmp
+    end
+
+    after :each do
+      temp_dir_after
+    end
+
+    it "should append to an existing Rakefile" do
+      FileUtils.cp("#{@old_dir}/spec/fixture/Rakefile", @tmp)
+      output = capture_stdout { Jasmine::CommandLineTool.new.process ["init"] }
+      output.should =~ /Jasmine has been installed with example specs./
+    end
+  end
+end


### PR DESCRIPTION
The existing spec code missed the bug because rake was probably required during an earlier test, so I split this spec in a separate file.

I tried several approaches to DRY up the spec code but none satisfied me enough so I ended up duplicating a few lines.
