### PR TITLE
Fixed deprecation warnings for current RubyGems.

### DIFF
--- a/lib/jasmine/base.rb
+++ b/lib/jasmine/base.rb
@@ -57,10 +57,14 @@ module Jasmine
   end
 
   def self.rspec2?
+    Gem::Specification::find_by_name "rspec", ">= 2.0"
+  rescue
     Gem.available? "rspec", ">= 2.0"
   end
   
   def self.rails3?
+    Gem::Specification::find_by_name "rails", ">= 3.0"
+  rescue
     Gem.available? "rails", ">= 3.0"
   end
 end


### PR DESCRIPTION
Replaced calls to Gem::available? with newer API.
