### PR TITLE
Issue for rails 2 apps

### DIFF
--- a/lib/jasmine/base.rb
+++ b/lib/jasmine/base.rb
@@ -57,6 +57,7 @@ module Jasmine
   end
   
   def self.rails3?
+    return Rails.version.split(".").first.to_i == 3 if defined? Rails
     Gem.available? "rails", ">= 3.0"
   end
 end


### PR DESCRIPTION
Getting an error with my rails 2 app when attempting to just run a normal (non-jasmine) rspec test.

```
12:25 ~/work/pipeline_deals (new_deals_page_rebase)$ bundle exec spec spec/models/person_spec.rb 

/Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/activesupport-2.3.11/lib/active_support/dependencies.rb:184:in `require': no such file to load -- rails/railtie (MissingSourceFile)
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/activesupport-2.3.11/lib/active_support/dependencies.rb:184:in `require'
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/jasmine-1.0.2.1/lib/jasmine/railtie.rb:1
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/activesupport-2.3.11/lib/active_support/dependencies.rb:184:in `require'
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/activesupport-2.3.11/lib/active_support/dependencies.rb:184:in `require'
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/jasmine-1.0.2.1/lib/jasmine.rb:13
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/bundler-1.0.13/lib/bundler/runtime.rb:68:in `require'
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/bundler-1.0.13/lib/bundler/runtime.rb:68:in `require'
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/bundler-1.0.13/lib/bundler/runtime.rb:66:in `each'
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/bundler-1.0.13/lib/bundler/runtime.rb:66:in `require'
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/bundler-1.0.13/lib/bundler/runtime.rb:55:in `each'
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/bundler-1.0.13/lib/bundler/runtime.rb:55:in `require'
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/bundler-1.0.13/lib/bundler.rb:120:in `require'
        from /Users/gammons/work/pipeline_deals/config/boot.rb:116:in `load_gems'
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/rails-2.3.11/lib/initializer.rb:164:in `process'
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/rails-2.3.11/lib/initializer.rb:113:in `send'
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/rails-2.3.11/lib/initializer.rb:113:in `run'
        from /Users/gammons/work/pipeline_deals/config/environment.rb:6
        from /Users/gammons/work/pipeline_deals/spec/spec_helper.rb:5:in `require'
        from /Users/gammons/work/pipeline_deals/spec/spec_helper.rb:5
        from ./spec/models/person_spec.rb:1:in `require'
        from ./spec/models/person_spec.rb:1
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/rspec-1.3.2/lib/spec/runner/example_group_runner.rb:15:in `load'
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/rspec-1.3.2/lib/spec/runner/example_group_runner.rb:15:in `load_files'
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/rspec-1.3.2/lib/spec/runner/example_group_runner.rb:14:in `each'
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/rspec-1.3.2/lib/spec/runner/example_group_runner.rb:14:in `load_files'
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/rspec-1.3.2/lib/spec/runner/options.rb:134:in `run_examples'
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/rspec-1.3.2/lib/spec/runner/command_line.rb:9:in `run'
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/gems/rspec-1.3.2/bin/spec:5
        from /Users/gammons/.rvm/gems/ruby-1.8.7-p334/bin/spec:19:in `load'
```

Patched your `rails3?` function, one liner.  Tests pass.
