### PR TITLE
Add :max_nesting => false to remove nesting limit

### DIFF
--- a/lib/jasmine/selenium_driver.rb
+++ b/lib/jasmine/selenium_driver.rb
@@ -45,7 +45,7 @@ module Jasmine
 
     def eval_js(script)
       result = @driver.execute_script(script)
-      JSON.parse("{\"result\":#{result}}")["result"]
+      JSON.parse("{\"result\":#{result}}", :max_nesting => false)["result"]
     end
 
     def json_generate(obj)


### PR DESCRIPTION
We were getting an error when running rake jasmine:ci:

/Users/my_user/.rvm/gems/ruby-1.9.2-p180@gemset/gems/json-1.5.3/lib/json/common.rb:148:in `parse': nesting of 20 is too deep (JSON::NestingError)
    from /Users/my_user/.rvm/gems/ruby-1.9.2-p180@gemset/gems/json-1.5.3/lib/json/common.rb:148:in`parse'
    from /Users/my_user/workspace/jasmine-gem/lib/jasmine/selenium_driver.rb:48:in `eval_js'
    from /Users/my_user/workspace/jasmine-gem/lib/jasmine/config.rb:60:in`eval_js'
    from /Users/my_user/workspace/jasmine-gem/lib/jasmine/spec_builder.rb:155:in `eval_js'
    from /Users/my_user/workspace/jasmine-gem/lib/jasmine/spec_builder.rb:61:in`load_suite_info'
    from /Users/my_user/workspace/jasmine-gem/lib/jasmine/spec_builder.rb:18:in `start'

This commit turns off the nesting limitation of JSON.parse when parsing the results of the Jasmine suite.
