### PR TITLE
keeping browsers from caching the files

### DIFF
--- a/lib/jasmine/server.rb
+++ b/lib/jasmine/server.rb
@@ -30,7 +30,7 @@ module Jasmine
       body = ERB.new(File.read(File.join(File.dirname(__FILE__), "run.html.erb"))).result(binding)
       [
         200,
-        { 'Content-Type' => 'text/html' },
+        { 'Content-Type' => 'text/html', 'Cache-Control' => 'no-cache', 'Pragma' => 'no-cache' },
         [body]
       ]
     end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -74,8 +74,15 @@ describe "Jasmine.app" do
     it "should return an empty 200 for HEAD requests to /" do
       head "/"
       last_response.status.should == 200
-      last_response.headers.should == { 'Content-Type' => 'text/html' }
+      last_response.headers['Content-Type'].should == 'text/html'
       last_response.body.should == ''
+    end
+
+    it "should tell the browser not to cache any assets" do
+      head "/"
+      ['Cache-Control', 'Pragma'].each do |key|
+        last_response.headers[key].should == 'no-cache'
+      end
     end
   end
 end


### PR DESCRIPTION
adding headers to the response will keep the browser from serving stale assets on refresh
