### PR TITLE
Small tweak to jasmine.rake when using the gem for developing an engine

### DIFF
--- a/lib/jasmine/tasks/jasmine.rake
+++ b/lib/jasmine/tasks/jasmine.rake
@@ -39,7 +39,7 @@ namespace :jasmine do
   end
 
   task :server => "jasmine:require" do
-    jasmine_config_overrides = './spec/javascripts/support/jasmine_config.rb'
+    jasmine_config_overrides = File.join(Jasmine::Config.new.project_root, 'spec', 'javascripts' ,'support' ,'jasmine_config.rb')
     require jasmine_config_overrides if File.exist?(jasmine_config_overrides)
 
     port = ENV['JASMINE_PORT'] || 8888


### PR DESCRIPTION
Don't assume that the config file is relative to ./spec/javascripts/support...
as this assumption won't be true if we're using this for developing an engine.
Instead rely on the project_root method, which we can patch for engine development.
Still a bit clunky but at least it works now.
