### PR TITLE
v0.11.1 - selenium_rc was deprecated causing errors

### DIFF
--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -4,8 +4,8 @@ module Jasmine
     require 'erb'
 
     def initialize(options = {})
-      require 'selenium_rc'
-      @selenium_jar_path = SeleniumRC::Server.allocate.jar_path
+      require 'selenium-rc'
+      @selenium_jar_path = SeleniumRC::Server.jar_path
 
       @browser = ENV["JASMINE_BROWSER"] || 'firefox'
       @selenium_pid = nil


### PR DESCRIPTION
Using rails v2.3.4, bundle gave us jasmine-gem v0.11.1.0

selenium_rc was deprecated, causing errors, so I modified it to selenium-rc and fixed the jar_path line.

Notes: 

I created this on a branch named v0.11.1.1, which since you dont have it, this pull request is asking you to merge into master... I'm new to pull requests, so I know thats not where this needs to be pulled/merged, but I dont know how else to request it.

I suppose it will also need to be merged into the master repo at the 0.11.1release tag on your end, which I dont even know if thats possible, but I assume it is, since git is usually pretty good about letting you do stuff like that.

Also, this probably only affects rails <= 2.3.X users, so I dont even know if it's worth the hassle for you to fix. But just in case, here it is.
