### PR TITLE
Rescue Gem::LoadError raised when gem isn't found

### DIFF
--- a/lib/jasmine/base.rb
+++ b/lib/jasmine/base.rb
@@ -49,7 +49,7 @@ module Jasmine
     return Rails.version.split(".").first.to_i == 3 if defined? Rails
     begin
       Gem::Specification::find_by_name "rails", ">= 3.0"
-    rescue
+    rescue Gem::LoadError
       Gem.available? "rails", ">= 3.0"
     end
   end


### PR DESCRIPTION
Running `jasmine init` in a non-Rails project using Ruby 1.9.2p180 and RubyGems 1.8.5 raised the following error:

```
Could not find rails (>= 3.0) amongst [...]
```

Being specific about rescuing `Gem::LoadError` fixed the issue. Perhaps this exception used to be some type of `StandardError` in a previous version of RubyGems?

Either way, I'd love to get this tested so it's able to be pulled in, but I just opened the code and am at a loss. Any suggestions would be helpful.
