### PR TITLE
Patch to fix issue 53 

### DIFF
--- a/generators/jasmine/templates/jasmine-example/SpecRunner.html
+++ b/generators/jasmine/templates/jasmine-example/SpecRunner.html
@@ -10,11 +10,11 @@
   <script type="text/javascript" src="lib/jasmine-1.1.0.rc1/jasmine.js"></script>
   <script type="text/javascript" src="lib/jasmine-1.1.0.rc1/jasmine-html.js"></script>
 
-  <!-- include source files here... -->
+  <!-- include spec files here... -->
   <script type="text/javascript" src="spec/SpecHelper.js"></script>
   <script type="text/javascript" src="spec/PlayerSpec.js"></script>
 
-  <!-- include spec files here... -->
+  <!-- include source files here... -->
   <script type="text/javascript" src="src/Player.js"></script>
   <script type="text/javascript" src="src/Song.js"></script>
 

--- a/lib/jasmine/base.rb
+++ b/lib/jasmine/base.rb
@@ -45,10 +45,12 @@ module Jasmine
     Gem.available? "rspec", ">= 2.0"
   end
 
-  def self.rails3?
+   def self.rails3?
     return Rails.version.split(".").first.to_i == 3 if defined? Rails
     begin
       Gem::Specification::find_by_name "rails", ">= 3.0"
+    rescue Gem::LoadError
+    	false
     rescue
       Gem.available? "rails", ">= 3.0"
     end


### PR DESCRIPTION
Issue 53,  'could not find rails', can only be noticed on ruby 1.9.2 p290. When rescue the exception without specifying the exception type, it seems ruby 1.9.2 p290 cannot rescue the exception. The exception will bubbled up and give the uses the error message 'could not find rails...'. Specifying the exception type fixes it.
