### PR TITLE
Fixing Gem::LoadError when using rails 2 and/or rspec 1

### DIFF
--- a/lib/jasmine/base.rb
+++ b/lib/jasmine/base.rb
@@ -41,7 +41,7 @@ module Jasmine
 
   def self.rspec2?
     Gem::Specification::find_by_name "rspec", ">= 2.0"
-  rescue
+  rescue Gem::LoadError
     Gem.available? "rspec", ">= 2.0"
   end
 
@@ -49,7 +49,7 @@ module Jasmine
     return Rails.version.split(".").first.to_i == 3 if defined? Rails
     begin
       Gem::Specification::find_by_name "rails", ">= 3.0"
-    rescue
+    rescue Gem::LoadError
       Gem.available? "rails", ">= 3.0"
     end
   end

--- a/spec/lib/base_spec.rb
+++ b/spec/lib/base_spec.rb
@@ -1,0 +1,16 @@
+require File.expand_path(File.join(File.dirname(__FILE__), "..","spec_helper"))
+
+describe Jasmine do
+  
+  describe "Rails version indentification" do
+    context "when gem is not available" do
+      it "should not break without rspec 2" do
+        Jasmine.rspec2?.should_not raise_error(Gem::LoadError)
+      end
+      
+      it "should not break without rails 3" do
+        Jasmine.rails3?.should_not raise_error(Gem::LoadError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a simple patch to avoid breaking rake tasks when using rails 2 or rspec 1.
