### PR TITLE
Change Version Checks To Allow Use of Rake Tasks from Rails Engines

### DIFF
--- a/lib/jasmine/base.rb
+++ b/lib/jasmine/base.rb
@@ -46,7 +46,7 @@ module Jasmine
   end
 
   def self.rails3?
-    return Rails.version.split(".").first.to_i == 3 if defined? Rails
+    return Rails::VERSION::MAJOR.to_i === 3 if defined?(Rails::VERSION)
     begin
       Gem::Specification::find_by_name "rails", ">= 3.0"
     rescue


### PR DESCRIPTION
Rails.version is unavailable from the Rails module unless all of Rails
is included. This breaks rake tasks when trying to run them from a Rails
Engine as usually ony rails/engine is included.
