### PR TITLE
rescue Exception to handle Gem::LoadError

### DIFF
--- a/lib/jasmine/base.rb
+++ b/lib/jasmine/base.rb
@@ -49,7 +49,7 @@ module Jasmine
     return Rails.version.split(".").first.to_i == 3 if defined? Rails
     begin
       Gem::Specification::find_by_name "rails", ">= 3.0"
-    rescue
+    rescue Exception
       Gem.available? "rails", ">= 3.0"
     end
   end


### PR DESCRIPTION
otherwise jasmine init fails without rails
