### PR TITLE
Jasmine wasn't loading (calling Jasmine before it's specified) so I've fixed it.

### DIFF
--- a/lib/jasmine.rb
+++ b/lib/jasmine.rb
@@ -1,3 +1,5 @@
+require File.join('jasmine', 'version')
+
 jasmine_files = ['base',
                  'config',
                  'server',


### PR DESCRIPTION
Require jasmine/version first so that the Jasmine namespace and Jasmine::RUBYGEMS_VERSION is available before invoking it in jasmine_files.

This fixes:

``` shell
$ bundle exec rspec spec/
/Users/parndt/.rvm/gems/ruby-1.8.7-p352/gems/jasmine-1.1.1/lib/jasmine.rb:4: uninitialized constant Jasmine (NameError)
```
