### PR TITLE
Require 'jasmin/version.rb' before using Jasmine constant.

### DIFF
--- a/lib/jasmine.rb
+++ b/lib/jasmine.rb
@@ -1,3 +1,5 @@
+require File.join('jasmine', 'version')
+
 jasmine_files = ['base',
                  'config',
                  'server',


### PR DESCRIPTION
This fixes an issue where 'rake -T' (and others) for rake 0.8.7 errors out
complaining about the missing constant Jasmine.
