### PR TITLE
add rails 3 asset pipeline for spec files

### DIFF
--- a/lib/jasmine/server.rb
+++ b/lib/jasmine/server.rb
@@ -78,13 +78,15 @@ module Jasmine
         map('/assets') do
           run Rails.application.assets
         end
+        map(config.spec_path)    { run Rails.application.assets }
+      else
+        map(config.spec_path)    { run Rack::File.new(config.spec_dir) }
       end
 
       map('/run.html')         { run Jasmine::Redirect.new('/') }
       map('/__suite__')        { run Jasmine::FocusedSuite.new(config) }
 
       map('/__JASMINE_ROOT__') { run Rack::File.new(Jasmine::Core.path) }
-      map(config.spec_path)    { run Rack::File.new(config.spec_dir) }
       map(config.root_path)    { run Rack::File.new(config.project_root) }
 
       map('/') do


### PR DESCRIPTION
Based on asset support : 0a2a9d2f504dd2264c5d08d56af479014be7c9c6
This pull request allows spec files written in coffeescript to be served using rails 3 asset pipeline.

add your spec dir to your rails assets paths:

``` ruby
#config/application.rb 
config.assets.paths << Rails.root.join("spec", "javascripts")
```

Any idea on how I could test this like :

``` ruby
    it "should serve coffeescript spec files using assets pipeline" do
      get "/__spec__/rails3_example_spec.js.coffee"
      last_response.status.should == 200
      last_response.content_type.should == "application/javascript"
      last_response.body.should == CoffeeScript.compile(File.join(@root, "fixture/src/rails3_example_spec.js.coffee"))
    end
```

``` ruby
#jasmine.yml
src_files:
  - assets/application.js

spec_files:
  - '**/*[sS]pec.js.coffee'

spec_dir: spec/javascripts

src_dir:

asset_pipeline_paths:
  - app/assets
  - spec/javascripts
```

We can improve this by :
- adding the spec dir to the rails app assets paths in jasmine-gem instead of config/application.rb
- writing more consistent tests
