### PR TITLE
Fixing the  asset pipeline detection code under rails 3.0

### DIFF
--- a/lib/jasmine/dependencies.rb
+++ b/lib/jasmine/dependencies.rb
@@ -15,7 +15,7 @@ module Jasmine
       end
 
       def rails_3_asset_pipeline?
-        rails3? && Rails.respond_to?(:application) && Rails.application.assets
+        rails3? && Rails.respond_to?(:application) && Rails.application.respond_to?(:assets) && Rails.application.assets
       end
 
       private


### PR DESCRIPTION
This fixes the asset pipeline detection code to not blow up under rails 3.0.
