### PR TITLE
Add compatibility with Rack version ~>1.0

### DIFF
--- a/jasmine.gemspec
+++ b/jasmine.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'json_pure'
 
   s.add_dependency 'jasmine-core', ">= 1.2.0.rc1"
-  s.add_dependency 'rack', '>= 1.1'
+  s.add_dependency 'rack', '~> 1.0'
   s.add_dependency 'rspec', '>= 1.3.1'
   s.add_dependency 'selenium-webdriver', '>= 0.1.3'
 end

--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -16,9 +16,14 @@ module Jasmine
     end
 
     def start_server(port = 8888)
-      server = Rack::Server.new(:Port => port, :AccessLog => [])
-      server.instance_variable_set(:@app, Jasmine.app(self)) # workaround for Rack bug, when Rack > 1.2.1 is released Rack::Server.start(:app => Jasmine.app(self)) will work
-      server.start
+      if defined? Rack::Server # Rack ~>1.0 compatibility
+        server = Rack::Server.new(:Port => port, :AccessLog => [])
+        server.instance_variable_set(:@app, Jasmine.app(self)) # workaround for Rack bug, when Rack > 1.2.1 is released Rack::Server.start(:app => Jasmine.app(self)) will work
+        server.start
+      else
+        handler = Rack::Handler.get('mongrel')
+        handler.run(Jasmine.app(self), :Port => port, :AccessLog => [])
+      end
     end
 
     def start

--- a/lib/jasmine/server.rb
+++ b/lib/jasmine/server.rb
@@ -74,7 +74,9 @@ module Jasmine
   def self.app(config)
     Rack::Builder.app do
       use Rack::Head
-      use Rack::ETag, "max-age=0, private, must-revalidate"
+      if defined? Rack::ETag # Rack ~>1.0 compatibility
+        use Rack::ETag, "max-age=0, private, must-revalidate"
+      end
       if Jasmine::Dependencies.rails_3_asset_pipeline?
         map('/assets') do
           run Rails.application.assets


### PR DESCRIPTION
This adds backward compatibility with Rack versions < 1.1.  Still lots of people on Rails < 2.3.6, this enables them to use Jasmine gem.
