### PR TITLE
Fix CI task with asset pipeline

### DIFF
--- a/lib/jasmine/tasks/jasmine.rake
+++ b/lib/jasmine/tasks/jasmine.rake
@@ -27,7 +27,7 @@ namespace :jasmine do
         t.rspec_opts = ["--colour", "--format", ENV['JASMINE_SPEC_FORMAT'] || "progress"]
         t.verbose = true
         if Jasmine::Dependencies.rails_3_asset_pipeline?
-          t.ruby_opts = ["-r #{File.expand_path(File.join(::Rails.root, 'config', 'environment'))}"]
+          t.rspec_opts += ["-r #{File.expand_path(File.join(::Rails.root, 'config', 'environment'))}"]
         end
         t.pattern = [Jasmine.runner_filepath]
       end


### PR DESCRIPTION
Update: So, I found this issue and addressed it, and then found that I was using an old rspec, 2.6.0, and this went away when I upgraded to >=2.7.0, so maybe you want to document a dependency of >=rspec-2.7.0 and/or reject this merge.

---

When I run the `jasmine:ci` task, the asset pipeline is not mounted, and my specs fail because `/assets/application.js` returns a 404.  Ruby 1.9.3-p235, Rails 3.1.0, jasmine-gem on edge (34c1529c3f7b).

Tracing this down, I found that `Jasmine::Dependencies.rails_3_asset_pipeline?` is returning `true` inside the `jasmine_continuous_integration_runner` rake task.  Then, the RSpec rake task is invoked, which eventually calls `Jasmine::Config#start_server` and `Jasmine.app` inside `/lib/jasmine/server.rb`, at which point the `.rails_3_asset_pipeline?` method returns false.

Inside the `.rails_3_asset_pipeline?` method, the difference is that `Rails.respond_to?(:application)` is originally returning true, but later returns false.  I suspected that Rails wasn't being loaded by the RSpec rake task correctly.

Changing the way Jasmine invokes the RSpec rake task from requiring `config/environment.rb` as a Ruby `-r` command line argument to an RSpec `-r` command line argument fixes this.

Details: https://gist.github.com/92c7e7ced6f3b1935712
