### PR TITLE
Allow users to mount their own rack apps

### DIFF
--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -15,6 +15,10 @@ module Jasmine
       ENV["JASMINE_PORT"] || Jasmine::find_unused_port
     end
 
+    def mount_apps
+      {}
+    end
+
     def start_server(port = 8888)
       if defined? Rack::Server # Rack ~>1.0 compatibility
         server = Rack::Server.new(:Port => port, :AccessLog => [])

--- a/lib/jasmine/server.rb
+++ b/lib/jasmine/server.rb
@@ -109,6 +109,12 @@ module Jasmine
           Jasmine::RunAdapter.new(config)
         ])
       end
+
+      config.mount_apps.each do |path, rack_app|
+        map(path) do
+          run rack_app
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This patch allows a user to mount their own rack apps within jasmine and have the jasmine runner load resources from the mount point.

For example on our project we can now use [rake pipeline](https://github.com/livingsocial/rake-pipeline) within jasmine
