### PR TITLE
Adding support to specify a custom rack environment to serve assets with the jasmine spec server

### DIFF
--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -168,5 +168,12 @@ module Jasmine
         []
       end
     end
+
+    def custom_environment
+    end
+
+    def custom_environment_path
+      '/assets'
+    end
   end
 end

--- a/lib/jasmine/server.rb
+++ b/lib/jasmine/server.rb
@@ -17,6 +17,13 @@ module Jasmine
     Rack::Builder.app do
       use Rack::Head
       use Rack::Jasmine::CacheControl
+
+      if config.custom_environment
+        map(config.custom_environment_path) do
+          run config.custom_environment
+        end
+      end
+
       if Jasmine::Dependencies.rails_3_asset_pipeline?
         map('/assets') do
           run Rails.application.assets

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -237,6 +237,18 @@ describe Jasmine::Config do
         ]
       end
     end
+
+    describe "custom environment" do
+      it "should return nil" do
+        @config.custom_environment.should be_nil
+      end
+    end
+
+    describe "custom environment path" do
+      it "should default to /assets" do
+        @config.custom_environment_path.should == '/assets'
+      end
+    end
   end
 
   describe "environment variables" do

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -12,6 +12,8 @@ describe "Jasmine.app" do
     config.stub!(:src_dir).and_return(File.join(@root, "fixture", "src"))
     config.stub!(:src_files).and_return(["file1.js"])
     config.stub!(:spec_files).and_return(["file2.js"])
+    config.stub!(:custom_environment).and_return(Proc.new { [200, {}, ["Hello, World!"]] })
+    config.stub!(:custom_environment_path).and_return('/custom_assets')
     Jasmine.app(config)
   end
 
@@ -90,6 +92,13 @@ describe "Jasmine.app" do
       ['Pragma'].each do |key|
         last_response.headers[key].should == 'no-cache'
       end
+    end
+  end
+
+  context "when a custom environment is configured" do
+    it "should serve assets from the configured path" do
+      get "/custom_assets"
+      last_response.body.should == 'Hello, World!'
     end
   end
 end


### PR DESCRIPTION
The idea here is to be able to use Sprockets (or any rack compatible framework) to serve assets, thus being able to write source code with any of the Sprockets supported features (like writing it with CoffeeScript, ERB, etc) and having it tested with Jasmine, all this without having to use Rails.

For example, one could add a jasmine-config.rb like this:

``` ruby
module Jasmine
  class Config
    def custom_environment
      Sprockets::Environment.new do |env|
        env.append_path 'public/javascripts'
      end
    end

    def custom_environment_path
      '/javascripts'
    end
  end
end
```

Now assets in `public/javascript` will be served by Sprockets, so you can use CoffeeScript, ERB, and all nice Sprockets features in your source code!
