### PR TITLE
deliver suite spec files with sprockets - mainly for coffee script support

### DIFF
--- a/generators/jasmine/templates/spec/javascripts/support/jasmine.yml
+++ b/generators/jasmine/templates/spec/javascripts/support/jasmine.yml
@@ -11,7 +11,7 @@
 #   - dist/**/*.js
 #
 src_files:
-    - public/javascripts/**/*.js
+    - assets/javascripts/application.js
 
 # stylesheets
 #
@@ -49,6 +49,7 @@ helpers:
 #   - **/*[sS]pec.js
 #
 spec_files:
+  - 'suite.js'
 
 # src_dir
 #

--- a/jasmine.gemspec
+++ b/jasmine.gemspec
@@ -70,4 +70,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'rack', '~> 1.0'
   s.add_dependency 'rspec', '>= 1.3.1'
   s.add_dependency 'selenium-webdriver', '>= 0.1.3'
+  s.add_dependency 'sprockets'
 end

--- a/lib/generators/jasmine/install/templates/spec/javascripts/suite.js
+++ b/lib/generators/jasmine/install/templates/spec/javascripts/suite.js
@@ -1,0 +1,4 @@
+// this is a manifest file that will be used to load your test suite
+//  Any JavaScript/Coffee file within this directory can be referenced here using a relative path.
+
+//= require_tree .

--- a/lib/generators/jasmine/install/templates/spec/javascripts/support/jasmine.yml
+++ b/lib/generators/jasmine/install/templates/spec/javascripts/support/jasmine.yml
@@ -27,19 +27,6 @@ src_files:
 stylesheets:
   - stylesheets/**/*.css
 
-# helpers
-#
-# Return an array of filepaths relative to spec_dir to include before jasmine specs.
-# Default: ["helpers/**/*.js"]
-#
-# EXAMPLE:
-#
-# helpers:
-#   - helpers/**/*.js
-#
-helpers:
-  - helpers/**/*.js
-
 # spec_files
 #
 # Return an array of filepaths relative to spec_dir to include.
@@ -51,7 +38,7 @@ helpers:
 #   - **/*[sS]pec.js
 #
 spec_files:
-  - '**/*[sS]pec.js'
+  - 'suite.js'
 
 # src_dir
 #

--- a/lib/jasmine/application.rb
+++ b/lib/jasmine/application.rb
@@ -6,6 +6,7 @@ require 'rack/jasmine/focused_suite'
 require 'rack/jasmine/redirect'
 require 'rack/jasmine/cache_control'
 require 'ostruct'
+require 'sprockets'
 
 module Jasmine
   class Application
@@ -20,12 +21,17 @@ module Jasmine
           end
         end
 
+        map(config.spec_path) do
+          environment = Sprockets::Environment.new
+          environment.append_path File.expand_path(config.spec_dir)
+          run environment
+        end
+
         map('/run.html')         { run Rack::Jasmine::Redirect.new('/') }
         map('/__suite__')        { run Rack::Jasmine::FocusedSuite.new(config) }
 
         #TODO: These path mappings should come from the config.
         map('/__JASMINE_ROOT__') { run Rack::File.new(Jasmine::Core.path) }
-        map(config.spec_path)    { run Rack::File.new(config.spec_dir) }
         map(config.root_path)    { run Rack::File.new(config.project_root) }
 
         map('/') do


### PR DESCRIPTION
I've been trying to write my jasmine specs with coffee-script. Considering how many apps get written in coffee script I guess this is just a logical step. 
Currently the jasmine-gem does not support specs in coffee-script - you have to precompile your spec files to JS first. 

I'm putting this pull request up for discussion. 
If we deliver the spec files via sprockets the sprockets gem can take care of the compilation. 

This might currently have some downsides, for example: not knowing the exact file and line numbers of failing spec - but I'm sure to find a solution for that. 

what are the general thoughts on this? 
