### PR TITLE
Refactored AssetPipelineMapper

### DIFF
--- a/lib/jasmine.rb
+++ b/lib/jasmine.rb
@@ -9,6 +9,7 @@ jasmine_files = ['base',
                  'command_line_tool',
                  'page',
                  'asset_pipeline_mapper',
+                 'sprockets_mapper',
                  'results_processor',
                  'results',
                  File.join('runners', 'http')]

--- a/lib/jasmine/application.rb
+++ b/lib/jasmine/application.rb
@@ -11,6 +11,9 @@ module Jasmine
   class Application
     def self.app(config = Jasmine::RunnerConfig.new)
       page = Jasmine::Page.new(config)
+      if Jasmine::Dependencies.rails_3_asset_pipeline?
+        config.src_mapper = Jasmine::AssetPipelineMapper.new
+      end
       Rack::Builder.app do
         use Rack::Head
         use Rack::Jasmine::CacheControl

--- a/lib/jasmine/asset_pipeline_mapper.rb
+++ b/lib/jasmine/asset_pipeline_mapper.rb
@@ -6,13 +6,12 @@ class Jasmine::AssetPipelineMapper
     context.extend(::Sprockets::Helpers::RailsHelper)
   end
 
-  def initialize(src_files, context = Jasmine::AssetPipelineMapper.context)
-    @src_files = src_files
+  def initialize(context = Jasmine::AssetPipelineMapper.context)
     @context = context
   end
 
-  def files
-    @src_files.map do |src_file|
+  def files(src_files)
+    src_files.map do |src_file|
     filename = src_file.gsub(/^assets\//, '').gsub(/\.js$/, '')
     @context.asset_paths.asset_for(filename, 'js').to_a.map { |p| @context.asset_path(p).gsub(/^\//, '') + "?body=true" }
     end.flatten.uniq

--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -1,5 +1,7 @@
 module Jasmine
   class Config
+    attr_accessor :src_mapper
+
     require 'yaml'
     require 'erb'
 
@@ -75,12 +77,12 @@ module Jasmine
     end
 
     def src_files
-      if simple_config['src_files'] && Jasmine::Dependencies.rails_3_asset_pipeline?
-        Jasmine::AssetPipelineMapper.new(simple_config['src_files']).files
-      elsif simple_config['src_files']
-        match_files(src_dir, simple_config['src_files'])
+      return [] unless simple_config['src_files']
+
+      if self.src_mapper
+        self.src_mapper.files(simple_config['src_files'])
       else
-        []
+        match_files(src_dir, simple_config['src_files'])
       end
     end
 

--- a/lib/jasmine/runner_config.rb
+++ b/lib/jasmine/runner_config.rb
@@ -56,5 +56,12 @@ module Jasmine
       @port ||= ENV["JASMINE_PORT"] || Jasmine.find_unused_port
     end
 
+    def src_mapper=(context)
+      @config.src_mapper = context
+    end
+
+    def src_mapper
+      @config.src_mapper
+    end
   end
 end

--- a/lib/jasmine/sprockets_mapper.rb
+++ b/lib/jasmine/sprockets_mapper.rb
@@ -1,0 +1,13 @@
+class Jasmine::SprocketsMapper
+  def initialize(context, mount_point = 'assets')
+    @context = context
+    @mount_point = mount_point
+  end
+
+  def files(src_files)
+    src_files.map do |src_file|
+      filename = src_file.gsub(/^assets\//, '').gsub(/\.js$/, '')
+      @context.find_asset(filename).to_a.map(&:logical_path).map(&:to_s)
+    end.flatten.uniq.map{|path| File.join(@mount_point, path).to_s + "?body=true"}
+  end
+end

--- a/spec/asset_pipeline_mapper_spec.rb
+++ b/spec/asset_pipeline_mapper_spec.rb
@@ -11,8 +11,8 @@ describe Jasmine::AssetPipelineMapper do
       asset_context.stub(:asset_path) do |asset|
         "/some_location/#{asset}"
       end
-      mapper = Jasmine::AssetPipelineMapper.new(src_files, asset_context)
-      mapper.files.should == ['some_location/asset1.js?body=true', 'some_location/asset2.js?body=true', 'some_location/asset3.js?body=true']
+      mapper = Jasmine::AssetPipelineMapper.new(asset_context)
+      mapper.files(src_files).should == ['some_location/asset1.js?body=true', 'some_location/asset2.js?body=true', 'some_location/asset3.js?body=true']
     end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -257,30 +257,22 @@ describe Jasmine::Config do
     end
   end
 
-  describe "when the asset pipeline is active" do
-    before do
-      Jasmine::Dependencies.stub(:rails_3_asset_pipeline?) { true }
-    end
-
+  describe "when the asset pipeline (or any other sprockets environment) is active" do
     let(:src_files) { ["assets/some.js", "assets/files.js"] }
+    let(:mapped_files) { ["some.js", "files.js"] }
+    let(:mapper) { double("mapper") }
 
     let(:config) do
       Jasmine::Config.new.tap do |config|
         #TODO: simple_config should be a passed in hash
         config.stub(:simple_config)  { { 'src_files' => src_files} }
+        config.src_mapper = mapper
       end
     end
 
-    it "should use AssetPipelineMapper to return src_files" do
-      mapped_files =  ["some.js", "files.js"]
-      Jasmine::AssetPipelineMapper.stub_chain(:new, :files).and_return(mapped_files)
+    it "should use the mapper to return src_files" do
+      mapper.should_receive(:files).with(src_files).and_return(mapped_files)
       config.src_files.should == mapped_files
-    end
-
-    it "should pass the config src_files to the AssetPipelineMapper" do
-      Jasmine::Config.stub(:simple_config)
-      Jasmine::AssetPipelineMapper.should_receive(:new).with(src_files).and_return(double("mapper").as_null_object)
-      config.src_files
     end
   end
 end

--- a/spec/runner_config_spec.rb
+++ b/spec/runner_config_spec.rb
@@ -123,9 +123,16 @@ describe Jasmine::RunnerConfig do
       Jasmine.stub(:find_unused_port).and_return('4321')
       config.port.should == '1234'
     end
-
-
   end
 
+  describe "src_mapper" do
+    it "should update the src_mapper in the user_config" do
+      config = Jasmine::RunnerConfig.new(user_config = Jasmine::Config.new)
+      mapper = double("mapper")
+      config.src_mapper = mapper
+      config.src_mapper.should == mapper
+      user_config.src_mapper.should == mapper
+    end
+  end
 end
 

--- a/spec/sprockets_mapper_spec.rb
+++ b/spec/sprockets_mapper_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Jasmine::SprocketsMapper do
+  describe "mapping files" do
+    it "should retrieve asset paths from the the sprockets environment for passed files" do
+      src_files = ["assets/application.js", "assets/other_manifest.js"]
+      asset1 = double("asset1", :logical_path => "asset1.js")
+      asset2 = double("asset2", :logical_path => "asset2.js")
+      asset3 = double("asset3", :logical_path => "asset3.js")
+      asset_context = double("Sprockets::Environment")
+      asset_context.stub_chain(:find_asset).with("application").and_return([asset1, asset2])
+      asset_context.stub_chain(:find_asset).with("other_manifest").and_return([asset1, asset3])
+      mapper = Jasmine::SprocketsMapper.new(asset_context, 'some_location')
+      mapper.files(src_files).should == ['some_location/asset1.js?body=true', 'some_location/asset2.js?body=true', 'some_location/asset3.js?body=true']
+    end
+  end
+end


### PR DESCRIPTION
... for jasmine to run with sprockets without the Rails Asset Pipeline

We are testing our JS app without Rails, but with sprockets. We have a need for the tests to split out the bundled application.js into its component js files. We did this by refactoring the AssetPipelineMapper into a plugin, #src_mapper, (of sorts) that is a property of Jasmine::Config.

We modified Jasmine::Application to create the asset pipeline mapper (instead of in Jasmine::Config). Interestingly, it simplifies Config and consolidates the Asset Pipeline responsibility into the Application class.

If you want to use your own src mapper, write your own Application class, as we did in commander and assign config.src_mapper. The source mapper class is required to implement only 1 method, #files(src_files), that does the right thing.

We rewrote the AssetPipelineMapper class slightly to conform to the new interface.

It seems that you could write a FileSystemMapper class to do the right thing as well, so the refactor "feels" right.

Stop by the GP Commander desks for a demo.

Ken Mayer & Vinson Chuong <pair+ken+vchuong@pivotallabs.com>
