### PR TITLE
Making batch size for fetching spec results configurable

### DIFF
--- a/lib/jasmine/run_specs.rb
+++ b/lib/jasmine/run_specs.rb
@@ -27,7 +27,7 @@ Jasmine::wait_for_listener(jasmine_runner_config.port, "jasmine server")
 puts "jasmine server started."
 
 results_processor = Jasmine::ResultsProcessor.new(jasmine_runner_config)
-results = Jasmine::Runners::HTTP.new(client, results_processor).run
+results = Jasmine::Runners::HTTP.new(client, results_processor, jasmine_runner_config.result_batch_size).run
 formatter = Jasmine::RspecFormatter.new
 formatter.format_results(results)
 

--- a/lib/jasmine/runner_config.rb
+++ b/lib/jasmine/runner_config.rb
@@ -63,5 +63,9 @@ module Jasmine
     def src_mapper
       @config.src_mapper
     end
+
+    def result_batch_size
+      ENV["JASMINE_RESULT_BATCH_SIZE"] ? ENV["JASMINE_RESULT_BATCH_SIZE"].to_i : 50
+    end
   end
 end

--- a/lib/jasmine/runners/http.rb
+++ b/lib/jasmine/runners/http.rb
@@ -3,9 +3,10 @@ module Jasmine
     class HTTP
       attr_accessor :suites
 
-      def initialize(client, results_processor)
+      def initialize(client, results_processor, result_batch_size)
         @client = client
         @results_processor = results_processor
+        @result_batch_size = result_batch_size
       end
 
       def run
@@ -31,7 +32,7 @@ module Jasmine
 
       def results_hash
         spec_results = {}
-        spec_ids.each_slice(50) do |slice|
+        spec_ids.each_slice(@result_batch_size) do |slice|
           spec_results.merge!(eval_js("var result = jsApiReporter.resultsForSpecs(#{json_generate(slice)}); if (window.Prototype && Object.toJSON) { return Object.toJSON(result) } else { return JSON.stringify(result) }"))
         end
         spec_results

--- a/spec/jasmine_self_test_spec.rb
+++ b/spec/jasmine_self_test_spec.rb
@@ -18,6 +18,6 @@ Jasmine::wait_for_listener(jasmine_runner_config.port, "jasmine server")
 puts "jasmine server started."
 
 results_processor = Jasmine::ResultsProcessor.new(jasmine_runner_config)
-results = Jasmine::Runners::HTTP.new(client, results_processor).run
+results = Jasmine::Runners::HTTP.new(client, results_processor, jasmine_runner_config.result_batch_size).run
 formatter = Jasmine::RspecFormatter.new
 formatter.format_results(results)

--- a/spec/runner_config_spec.rb
+++ b/spec/runner_config_spec.rb
@@ -134,5 +134,18 @@ describe Jasmine::RunnerConfig do
       user_config.src_mapper.should == mapper
     end
   end
+
+  describe "result batch size" do
+    subject { Jasmine::RunnerConfig.new }
+
+    context "when not specified" do
+      it("should use default") { subject.result_batch_size.should be(50) }
+    end
+
+    context "when overridden" do
+      before { ENV.stub(:[], "JASMINE_RESULT_BATCH_SIZE").and_return("500") }
+      it { subject.result_batch_size.should be(500) }
+    end
+  end
 end
 


### PR DESCRIPTION
We have found with some of our environments that increasing the batch size could greatly reduce the time required to run a suite. I left the default as is, and added an easy means of overriding it.
