### PR TITLE
Added extended js timeouts as env variable

### DIFF
--- a/lib/jasmine/selenium_driver.rb
+++ b/lib/jasmine/selenium_driver.rb
@@ -7,12 +7,23 @@ module Jasmine
       elsif ENV['SELENIUM_SERVER_PORT']
         "http://localhost:#{ENV['SELENIUM_SERVER_PORT']}/wd/hub"
       end
+
+      profile = nil
+
       options = if browser == "firefox" && ENV["JASMINE_FIREBUG"]
                   require File.join(File.dirname(__FILE__), "firebug/firebug")
                   profile = Selenium::WebDriver::Firefox::Profile.new
                   profile.enable_firebug
                   {:profile => profile}
                 end || {}
+
+      if ENV['EXTENDED_JS_TIMEOUT']
+        profile ||= Selenium::WebDriver::Firefox::Profile.new
+        profile['dom.max_chrome_script_run_time'] = ENV['EXTENDED_JS_TIMEOUT'].to_i
+        profile['dom.max_script_run_time'] = ENV['EXTENDED_JS_TIMEOUT'].to_i
+        options = {:profile => profile}
+      end
+
       @driver = if selenium_server
         Selenium::WebDriver.for :remote, :url => selenium_server, :desired_capabilities => browser.to_sym
       else


### PR DESCRIPTION
This allows you to tune the built in javascript timeout options within firefox using an ENV variable. This is tuned using:

dom.max_chrome_script_run_time
dom.max_script_run_time

I was unsure about how to test this code, I looked for tests around the firebug support, and couldn't find any. I would be happy to provide specs if someone points me in the right direction.
