### PR TITLE
Encapsulating how the jasmine server url is constructed

### DIFF
--- a/lib/jasmine/run_specs.rb
+++ b/lib/jasmine/run_specs.rb
@@ -12,8 +12,7 @@ end
 
 jasmine_runner_config = Jasmine::RunnerConfig.new
 server = Jasmine::Server.new(jasmine_runner_config.port, Jasmine::Application.app(jasmine_runner_config))
-client = Jasmine::SeleniumDriver.new(jasmine_runner_config.browser,
-                                     "#{jasmine_runner_config.jasmine_host}:#{jasmine_runner_config.port}/")
+client = Jasmine::SeleniumDriver.new(jasmine_runner_config.browser, jasmine_runner_config.jasmine_server_url)
 
 t = Thread.new do
   begin

--- a/lib/jasmine/runner_config.rb
+++ b/lib/jasmine/runner_config.rb
@@ -48,6 +48,10 @@ module Jasmine
       ENV["JASMINE_BROWSER"] || 'firefox'
     end
 
+    def jasmine_server_url
+      "#{jasmine_host}:#{port}/"
+    end
+
     def jasmine_host
       ENV["JASMINE_HOST"] || 'http://localhost'
     end

--- a/spec/jasmine_self_test_spec.rb
+++ b/spec/jasmine_self_test_spec.rb
@@ -3,8 +3,7 @@ require 'jasmine_self_test_config'
 
 jasmine_runner_config = Jasmine::RunnerConfig.new(JasmineSelfTestConfig.new)
 server = Jasmine::Server.new(jasmine_runner_config.port, Jasmine::Application.app(jasmine_runner_config))
-client = Jasmine::SeleniumDriver.new(jasmine_runner_config.browser,
-                                     "#{jasmine_runner_config.jasmine_host}:#{jasmine_runner_config.port}/")
+client = Jasmine::SeleniumDriver.new(jasmine_runner_config.browser, jasmine_runner_config.jasmine_server_url)
 
 t = Thread.new do
   begin

--- a/spec/runner_config_spec.rb
+++ b/spec/runner_config_spec.rb
@@ -135,16 +135,29 @@ describe Jasmine::RunnerConfig do
     end
   end
 
+  describe "jasmine_server_url" do
+    subject { Jasmine::RunnerConfig.new.jasmine_server_url }
+
+    let(:host) { "the host" }
+    let(:port) { "484" }
+    before do
+      Jasmine::RunnerConfig.any_instance.should_receive(:jasmine_host).and_return(host)
+      Jasmine::RunnerConfig.any_instance.should_receive(:port).and_return(port)
+    end
+
+    it("") { should eq("#{host}:#{port}/")}
+  end
+
   describe "result batch size" do
-    subject { Jasmine::RunnerConfig.new }
+    subject { Jasmine::RunnerConfig.new.result_batch_size }
 
     context "when not specified" do
-      it("should use default") { subject.result_batch_size.should be(50) }
+      it("should use default") { should eq(50) }
     end
 
     context "when overridden" do
       before { ENV.stub(:[], "JASMINE_RESULT_BATCH_SIZE").and_return("500") }
-      it { subject.result_batch_size.should be(500) }
+      it { should be(500) }
     end
   end
 end


### PR DESCRIPTION
Provides greater flexibility for when it needs to be customized. We use saucelabs to run our tests, and need to be able to customize the URL for that environment
