### PR TITLE
Feature/extended timeouts

### DIFF
--- a/lib/jasmine/selenium_driver.rb
+++ b/lib/jasmine/selenium_driver.rb
@@ -8,21 +8,18 @@ module Jasmine
         "http://localhost:#{ENV['SELENIUM_SERVER_PORT']}/wd/hub"
       end
 
-      profile = nil
-
-      options = if browser == "firefox" && ENV["JASMINE_FIREBUG"]
-                  require File.join(File.dirname(__FILE__), "firebug/firebug")
+      options = if browser == "firefox"
                   profile = Selenium::WebDriver::Firefox::Profile.new
-                  profile.enable_firebug
+                  if ENV["JASMINE_FIREBUG"]
+                    require File.join(File.dirname(__FILE__), "firebug/firebug")
+                    profile.enable_firebug
+                  end
+                  if ENV["EXTENDED_JS_TIMEOUT"]
+                    profile['dom.max_chrome_script_run_time'] = ENV['EXTENDED_JS_TIMEOUT'].to_i
+                    profile['dom.max_script_run_time'] = ENV['EXTENDED_JS_TIMEOUT'].to_i
+                  end
                   {:profile => profile}
                 end || {}
-
-      if ENV['EXTENDED_JS_TIMEOUT']
-        profile ||= Selenium::WebDriver::Firefox::Profile.new
-        profile['dom.max_chrome_script_run_time'] = ENV['EXTENDED_JS_TIMEOUT'].to_i
-        profile['dom.max_script_run_time'] = ENV['EXTENDED_JS_TIMEOUT'].to_i
-        options = {:profile => profile}
-      end
 
       @driver = if selenium_server
         Selenium::WebDriver.for :remote, :url => selenium_server, :desired_capabilities => browser.to_sym


### PR DESCRIPTION
This allows you to tune the built in javascript timeout options within firefox using an ENV variable. This is tuned using:

dom.max_chrome_script_run_time
dom.max_script_run_time

This was refactored to only work within Firefox based on the comments on: https://github.com/pivotal/jasmine-gem/pull/105
