### PR TITLE
Re-fix issue #70 - uninitialized constant Jasmine::SeleniumDriver::JSON

### DIFF
--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -4,6 +4,7 @@ module Jasmine
 
     require 'yaml'
     require 'erb'
+    require 'json'
 
     def match_files(dir, patterns)
       dir = File.expand_path(dir)


### PR DESCRIPTION
It seems the fix was removed in 8642ce5. lib/jasmine/config.rb doesn't require json on HEAD and when I bundle against HEAD I get the above error.

If I add require 'json' after require 'erb' in lib/jasmine/config.rb then the error goes away. All the tests pass or are pending.
