### PR TITLE
Fixing incompatibility with jasmine-prototype javascript plugin when loading fixtures

### DIFF
--- a/lib/jasmine/application.rb
+++ b/lib/jasmine/application.rb
@@ -5,6 +5,7 @@ require 'rack/jasmine/runner'
 require 'rack/jasmine/focused_suite'
 require 'rack/jasmine/redirect'
 require 'rack/jasmine/cache_control'
+require 'rack/jasmine/ajax_quick_fix'
 require 'ostruct'
 
 module Jasmine
@@ -33,6 +34,7 @@ module Jasmine
 
         map('/') do
           run Rack::Cascade.new([
+            Rack::Jasmine::AjaxQuickFix.new(),
             Rack::URLMap.new('/' => Rack::File.new(config.src_dir)),
             Rack::Jasmine::Runner.new(page)
           ])

--- a/lib/rack/jasmine/ajax_quick_fix.rb
+++ b/lib/rack/jasmine/ajax_quick_fix.rb
@@ -1,0 +1,12 @@
+module Rack
+  module Jasmine
+
+    class AjaxQuickFix
+      def call(env)
+        env["REQUEST_METHOD"] = 'GET' if env["REQUEST_METHOD"] == "POST"
+        [404,{}, [] ]
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Hello

I'm using [jamine-prototype](https://github.com/masylum/jasmine-prototype) plugin with Jasmine gem. 

When loading html fixtures (using the `loadFixtures` helper), an ajax request is sent the rack server. This request is not handled correctly and it returns a 404 error. 

This commit is a quick fix.
