### PR TITLE
fix reference error of YAML and JSON

### DIFF
--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -1,4 +1,5 @@
 module Jasmine
+  require 'yaml'
   require 'erb'
   def self.configure(&block)
     block.call(self.config)

--- a/lib/jasmine/selenium_driver.rb
+++ b/lib/jasmine/selenium_driver.rb
@@ -1,4 +1,5 @@
 module Jasmine
+  require 'json'
   class SeleniumDriver
     def initialize(browser, http_address)
       require 'selenium-webdriver'


### PR DESCRIPTION
v1.3.1 is broken? `rake jasmine:ci` fail with reference error.

```
$ gem uninstall jasmine -a
$ gem install jasmine -v 1.3.1
$ mkdir temp && cd $_
$ jasmine init
$ rake jasmine:ci
/Users/k-nakamura/.rvm/rubies/ruby-1.9.3-p194/bin/ruby -S rspec /Users/k-nakamura/.rvm/gems/ruby-1.9.3-p194/gems/jasmine-1.3.1/lib/jasmine/run_specs.rb --colour --format progress
/Users/k-nakamura/.rvm/gems/ruby-1.9.3-p194/gems/jasmine-1.3.1/lib/jasmine/config.rb:69:in `block in load_configuration_from_yaml': uninitialized constant Jasmine::YAML (NameError)
...
```

adding `require 'yaml'` to config.rb, another error occurs.

```
$ rake jasmine:ci
/Users/k-nakamura/.rvm/rubies/ruby-1.9.3-p194/bin/ruby -S rspec /Users/k-nakamura/.rvm/gems/ruby-1.9.3-p194/gems/jasmine-1.3.1/lib/jasmine/run_specs.rb --colour --format progress
Waiting for jasmine server on 59432...
[2012-12-04 18:44:13] INFO  WEBrick 1.3.1
[2012-12-04 18:44:13] INFO  ruby 1.9.3 (2012-04-20) [x86_64-darwin12.2.0]
[2012-12-04 18:44:13] INFO  WEBrick::HTTPServer#start: pid=33916 port=59432
Waiting for jasmine server on 59432...
jasmine server started.
/Users/k-nakamura/.rvm/gems/ruby-1.9.3-p194/gems/jasmine-1.3.1/lib/jasmine/selenium_driver.rb:34:in `eval_js': uninitialized constant Jasmine::SeleniumDriver::JSON (NameError)
...
```
## environment

```
$ sw_vers
ProductName:    Mac OS X
ProductVersion: 10.8.2
BuildVersion:   12C60
$ rvm --version && ruby --version && rake --version

rvm 1.16.8 (stable) by Wayne E. Seguin <wayneeseguin@gmail.com>, Michal Papis <mpapis@gmail.com> [https://rvm.io/]

ruby 1.9.3p194 (2012-04-20 revision 35410) [x86_64-darwin12.2.0]
rake, version 10.0.2
```
