### PR TITLE
added a possibility to configure the selenium webdriver timeout, and rep...

### DIFF
--- a/lib/jasmine/selenium_driver.rb
+++ b/lib/jasmine/selenium_driver.rb
@@ -1,5 +1,10 @@
-module Jasmine
+begin
   require 'json'
+rescue LoadError
+  puts "You must have a JSON library installed to run jasmine:ci. Try \"gem install json\""
+end
+
+module Jasmine
   class SeleniumDriver
     def initialize(browser, http_address)
       require 'selenium-webdriver'
@@ -14,6 +19,13 @@ module Jasmine
                   profile.enable_firebug
                   {:profile => profile}
                 end || {}
+      
+      if ENV['JASMINE_TIMEOUT']
+        http_client = Selenium::WebDriver::Remote::Http::Default.new
+        http_client.timeout = ENV['JASMINE_TIMEOUT'].to_i
+        options.merge! :http_client => http_client
+      end
+      
       @driver = if selenium_server
         Selenium::WebDriver.for :remote, :url => selenium_server, :desired_capabilities => browser.to_sym
       else

--- a/spec/selenium_driver_spec.rb
+++ b/spec/selenium_driver_spec.rb
@@ -1,0 +1,120 @@
+require 'spec_helper'
+require 'selenium-webdriver'
+
+describe Jasmine::SeleniumDriver do
+  let(:http_client) { mock('http_client', :timeout= => true) }
+  let(:webdriver) { mock('webdriver') }
+  let(:browser) { "browser" }
+  
+  describe "initialize" do
+    subject { Jasmine::SeleniumDriver }
+    context "with a given server" do
+      before(:each) do
+        ENV.stub!(:[]).with('JASMINE_TIMEOUT').and_return nil
+        ENV.stub!(:[]).with('SELENIUM_SERVER').and_return "http://localhost:9999/"
+        Selenium::WebDriver.should_receive(:for).with(:remote, :url => "http://localhost:9999/", :desired_capabilities => :browser).and_return webdriver
+      end
+      it "should initialize the server with the given url" do
+        subject.new(browser, "http://localhost:9999/").instance_variable_get(:@driver).should == webdriver
+      end
+      it "should assign the http_address" do
+        subject.new(browser, "http://localhost:9999/").instance_variable_get(:@http_address).should == "http://localhost:9999/"
+      end
+    end
+    context "with a given port" do
+      before(:each) do
+        ENV.stub!(:[]).with('JASMINE_TIMEOUT').and_return nil
+        ENV.stub!(:[]).with('SELENIUM_SERVER').and_return nil
+        ENV.stub!(:[]).with('SELENIUM_SERVER_PORT').and_return "9999"
+        Selenium::WebDriver.should_receive(:for).with(:remote, :url => "http://localhost:9999/wd/hub", :desired_capabilities => :browser).and_return webdriver
+      end
+      it "should initialize the server with the given url" do
+        subject.new(browser, "http://localhost:9999/").instance_variable_get(:@driver).should == webdriver
+      end
+      it "should assign the http_address" do
+        subject.new(browser, "http://localhost:9999/").instance_variable_get(:@http_address).should == "http://localhost:9999/"
+      end
+    end
+    context "with no given server or port" do
+      before(:each) do
+        ENV.stub! :[] => nil
+        Selenium::WebDriver.should_receive(:for).with(:browser, {}).and_return webdriver
+      end
+      it "should initialize the server with the given url" do
+        subject.new(browser, "http://localhost:9999/").instance_variable_get(:@driver).should == webdriver
+      end
+      it "should assign the http_address" do
+        subject.new(browser, "http://localhost:9999/").instance_variable_get(:@http_address).should == "http://localhost:9999/"
+      end
+    end
+    context "with a given timeout" do
+      before(:each) do
+        ENV.stub!(:[]).with('SELENIUM_SERVER').and_return nil
+        ENV.stub!(:[]).with('SELENIUM_SERVER_PORT').and_return nil
+        ENV.stub!(:[]).with('JASMINE_FIREBUG').and_return nil
+        ENV.stub!(:[]).with('JASMINE_TIMEOUT').and_return "500"
+      end
+      it "should initialize the server with the given timeout" do
+        Selenium::WebDriver::Remote::Http::Default.should_receive(:new).and_return(http_client)
+        http_client.should_receive(:timeout=).with(500)
+        Selenium::WebDriver.should_receive(:for).with(:browser, {:http_client => http_client}).and_return webdriver
+        subject.new(browser, "http://localhost:9999/").instance_variable_get(:@driver).should == webdriver
+      end
+    end
+    context "with firebug" do
+      let(:browser) { "firefox" }
+      let(:profile) { mock('firefox_profile') }
+      before(:each) do
+        ENV.stub!(:[]).with('SELENIUM_SERVER').and_return nil
+        ENV.stub!(:[]).with('SELENIUM_SERVER_PORT').and_return nil
+        ENV.stub!(:[]).with('JASMINE_FIREBUG').and_return "true"
+        ENV.stub!(:[]).with('JASMINE_TIMEOUT').and_return nil
+      end
+      it "should initialize firefox with firebug" do
+        Selenium::WebDriver::Firefox::Profile.should_receive(:new).and_return profile
+        profile.should_receive(:enable_firebug)
+        Selenium::WebDriver.should_receive(:for).with(:firefox, {:profile => profile}).and_return webdriver
+        subject.new(browser, "http://localhost:9999/").instance_variable_get(:@driver).should == webdriver
+      end
+    end
+  end
+  
+  describe "instance methods" do
+    subject { Jasmine::SeleniumDriver.new("browser", 'http://fake.url') }
+    before(:each) do
+      ENV.stub! :[] => nil
+      Selenium::WebDriver.stub! :for => webdriver
+      Selenium::WebDriver::Remote::Http::Default.stub! :new => http_client
+      subject.instance_variable_set(:@driver, webdriver)
+    end
+    describe "connect" do
+      let(:navigator) { mock('navigator') }
+      it "should tell the driver to navigate to the given url" do
+        webdriver.should_receive(:navigate).and_return navigator
+        navigator.should_receive(:to).with('http://fake.url')
+        subject.connect
+      end
+    end
+    describe "disconnect" do
+      it "should tell the driver to quit" do
+        webdriver.should_receive(:quit)
+        subject.disconnect
+      end
+    end
+    describe "eval_js" do
+      it "should execute the given script and return a result" do
+        webdriver.should_receive(:execute_script).with('SCRIPT').and_return('json')
+        JSON.should_receive(:parse).with("{\"result\":json}", :max_nesting => false).and_return "result" => 'RESULT'
+        subject.eval_js('SCRIPT').should == 'RESULT'
+      end
+    end
+    describe "json_generate" do
+      it "should delegate to json" do
+        JSON.should_receive(:generate).with('something').and_return 'json'
+        subject.json_generate('something').should == 'json'
+      end
+    end
+  end
+
+  
+end


### PR DESCRIPTION
...eated the json load try in selenium.

The given default timeout for selenium (30sec) may not be enough to run a big suite in ci mode. I added a env configuration possibility to increase the timeout. Also, in our environment,  the ci task failed with "uninitialized constant Jasmine::SeleniumDriver::JSON" despite the prerequisite in the rakefile. I repeated the require in the given class and added specs.
