### PR TITLE
 Don't explicitly add src_path to expanded paths as Sprockets does that

### DIFF
--- a/lib/jasmine/asset_expander.rb
+++ b/lib/jasmine/asset_expander.rb
@@ -8,11 +8,9 @@ module Jasmine
     def expand(src_dir, src_path)
       pathname = src_path.gsub(/^\/?assets\//, '').gsub(/\.js$/, '')
       bundled_asset = @bundled_asset_factory.call(pathname, 'js')
-      return nil unless bundled_asset
-
-      bundled_asset.to_a.map do |asset|
+      bundled_asset && bundled_asset.to_a.map do |asset|
         "/#{@asset_path_for.call(asset).gsub(/^\//, '')}?body=true"
-      end.flatten
+      end
     end
   end
 end


### PR DESCRIPTION
Otherwise we'll end up with messed up wrong paths being included, like `/Users/foo/app/javascripts/bla.js.erb`. Leave expanding up to Sprockets which includes the source file if it has `require_self`.
