### PR TITLE
Fixes file-ordering bug in files loaded from jasmine.yml

### DIFF
--- a/lib/jasmine/path_expander.rb
+++ b/lib/jasmine/path_expander.rb
@@ -10,7 +10,7 @@ module Jasmine
             files = [File.join(base_directory, path)]
           end
           files
-        end.flatten.uniq
+        end.flatten.uniq.sort
       end
       chosen - negated
     end


### PR DESCRIPTION
On OSX, directory contents are always ordered the same, due to OSX's HFS+ file system. On Linux machines however, directory contents do not have a defined order.

This means every OSX system will load the files in the same order, but different linux machines will load the files in different orders. This pull request sorts the files specified in the jasmine.yml so that the file-order is the same across file-systems.

If a user had a jasmine.yml with

```
helpers:
  - "helpers/sinon/*.js"
```

Then the sinon scripts will likely be included out of order, causing exceptions when a dependency is not defined.
