### PR TITLE
Allow optional timeout setting for selenium HTTP driver for long running test suites

### DIFF
--- a/lib/jasmine/selenium_driver.rb
+++ b/lib/jasmine/selenium_driver.rb
@@ -3,6 +3,8 @@ module Jasmine
   class SeleniumDriver
     def initialize(browser, http_address)
       require 'selenium-webdriver'
+      @http_driver = Selenium::WebDriver::Remote::Http::Default.new
+      @http_driver.timeout = ENV['JASMINE_HTTP_TIMEOUT'] ? ENV['JASMINE_HTTP_TIMEOUT'].to_i : 120
       selenium_server = if ENV['SELENIUM_SERVER']
         ENV['SELENIUM_SERVER']
       elsif ENV['SELENIUM_SERVER_PORT']
@@ -14,8 +16,9 @@ module Jasmine
                   profile.enable_firebug
                   {:profile => profile}
                 end || {}
+      options[:http_client] = @http_driver
       @driver = if selenium_server
-        Selenium::WebDriver.for :remote, :url => selenium_server, :desired_capabilities => browser.to_sym
+        Selenium::WebDriver.for :remote, :url => selenium_server, :desired_capabilities => browser.to_sym, :http_client => @http_driver
       else
         Selenium::WebDriver.for browser.to_sym, options
       end


### PR DESCRIPTION
set ENV['JASMINE_HTTP_TIMEOUT'] to use

---

Our test suite is fairly large and hits the internal selenium http timeout on two of our CI services.  This allows setting a new timeout.  Defaults to 120.
