### PR TITLE
Correctly load rake tasks for Rails 4

### DIFF
--- a/lib/jasmine.rb
+++ b/lib/jasmine.rb
@@ -26,6 +26,6 @@ end
   # require File.join('rack', 'jasmine', file)
 # end
 
-require File.join('jasmine', "railtie") if Jasmine::Dependencies.rails3?
+require File.join('jasmine', "railtie") if Jasmine::Dependencies.at_least_rails3?
 
 

--- a/lib/jasmine/dependencies.rb
+++ b/lib/jasmine/dependencies.rb
@@ -14,8 +14,8 @@ module Jasmine
         safe_gem_check("rails", "< 2.3.11") && running_legacy_rails?
       end
 
-      def rails3?
-        safe_gem_check("rails", ">= 3.0") && running_rails3?
+      def at_least_rails3?
+        safe_gem_check("rails", ">= 3.0") && running_at_least_rails3?
       end
 
       def legacy_rack?
@@ -23,7 +23,7 @@ module Jasmine
       end
 
       def rails_3_asset_pipeline?
-        rails3? && Rails.respond_to?(:application) && Rails.application.respond_to?(:assets) && Rails.application.assets
+        at_least_rails3? && Rails.respond_to?(:application) && Rails.application.respond_to?(:assets) && Rails.application.assets
       end
 
       private
@@ -36,8 +36,8 @@ module Jasmine
         running_rails? && Rails.version.to_i == 2
       end
 
-      def running_rails3?
-        running_rails? && Rails.version.to_i == 3
+      def running_at_least_rails3?
+        running_rails? && Rails.version.to_i >= 3
       end
 
       def running_rails?

--- a/spec/dependencies_spec.rb
+++ b/spec/dependencies_spec.rb
@@ -78,7 +78,7 @@ if Jasmine::Dependencies.rspec2?
       end
 
       describe ".rails3?" do
-        subject { Jasmine::Dependencies.rails3? }
+        subject { Jasmine::Dependencies.at_least_rails3? }
         context "when rails 3 is present and running" do
           before do
             Gem::Specification.should_receive(:find_by_name).with("rails", ">= 3.0").and_return(true)
@@ -240,7 +240,7 @@ if Jasmine::Dependencies.rspec2?
       end
 
       describe ".rails3?" do
-        subject { Jasmine::Dependencies.rails3? }
+        subject { Jasmine::Dependencies.at_least_rails3? }
         before do
           Gem.should_receive(:available?).with("rails", ">= 3.0").and_return(rails3_present)
         end

--- a/spec/jasmine_rails3_spec.rb
+++ b/spec/jasmine_rails3_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Jasmine::Dependencies.rails3?
+if Jasmine::Dependencies.at_least_rails3?
 
   describe "A Rails 3 app" do
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,7 @@ end
 
 
 def create_rails(name)
-  if Jasmine::Dependencies.rails3?
+  if Jasmine::Dependencies.at_least_rails3?
     `rails new #{name}`
   else
     `rails #{name}`


### PR DESCRIPTION
I was trying to use the jasmine-gem with a Rails 4 project, but the rake tasks weren't being loaded correctly (didn't show up in rake -T).

Turns out the dependency manager was only loading the railtie for Rails versions 3.x, so I changed it to check if the Rails version was greater than 3.
