### PR TITLE
Fix default path for :spec_helper in template

### DIFF
--- a/generators/jasmine/templates/spec/javascripts/support/jasmine.yml
+++ b/generators/jasmine/templates/spec/javascripts/support/jasmine.yml
@@ -77,12 +77,12 @@ spec_dir:
 #
 # Ruby file that Jasmine server will require before starting.
 # Returned relative to your root path
-# Default spec/support/jasmine_helper.rb
+# Default spec/javascripts/support/jasmine_helper.rb
 #
 # EXAMPLE:
 #
-# spec_helper: spec/support/jasmine_helper.rb
+# spec_helper: spec/javascripts/support/jasmine_helper.rb
 #
-spec_helper: spec/support/jasmine_helper.rb
+spec_helper: spec/javascripts/support/jasmine_helper.rb
 
 


### PR DESCRIPTION
The default path was wrong. I wonder if anyone uses this feature?
