### PR TITLE
Allow user to change browser through yml config

### DIFF
--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -78,6 +78,7 @@ module Jasmine
         config.css_files = lambda { yaml_config.css_files }
         config.src_dir = yaml_config.src_dir
         config.spec_dir = yaml_config.spec_dir
+        config.browser = yaml_config.browser if yaml_config.browser
       end
       require yaml_config.spec_helper if File.exist?(yaml_config.spec_helper)
     end

--- a/lib/jasmine/yaml_config_parser.rb
+++ b/lib/jasmine/yaml_config_parser.rb
@@ -50,6 +50,10 @@ module Jasmine
       File.join(@pwd, loaded_yaml['spec_helper'] || File.join('spec', 'javascripts', 'support', 'jasmine_helper.rb'))
     end
 
+    def browser
+      loaded_yaml['browser']
+    end
+
     private
     def loaded_yaml
       @yaml_loader.call(@path)


### PR DESCRIPTION
Recently I updated to jquery 1.9.1 and the jasmine tests failed mysteriously when being runned through `rake jasmine:ci`. All the tests run just fine when being run through a regular browser. Upon closer inspect, I realized that there were some weird behaviors of the firefox browser launched by `rake jasmine:ci`. Thus I managed to run its through Chrome and all tests pass. This pull request allow user to specify her favorite browser from config file so that the mysterious fail can be avoided (Closing #138)
