### PR TITLE
Problem when using a asset prefix other than '/assets'

### DIFF
--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -43,7 +43,7 @@ module Jasmine
         )
         Jasmine::AssetPipelineMapper.new(config, asset_expander.method(:expand))
       })
-      @config.add_rack_path('/assets', lambda {
+      @config.add_rack_path(Rails.application.config.assets.prefix, lambda {
         # In order to have asset helpers like asset_path and image_path, we need to require 'action_view/base'.  This
         # triggers run_load_hooks on action_view which, in turn, causes sprockets/railtie to load the Sprockets asset
         # helpers.  Alternatively, you can include the helpers yourself without loading action_view/base:


### PR DESCRIPTION
In our environment we changed the asset prefix. This is picked up by the script-tags in the runner but the rack server doesn't find the files.
This is because you hardcoded '/assets' as the prefix in config.rb.
