### PR TITLE
Bug fix: Nested describes don't build full test name string correctly

### DIFF
--- a/lib/jasmine/rspec_formatter.rb
+++ b/lib/jasmine/rspec_formatter.rb
@@ -20,7 +20,8 @@ module Jasmine
       children.each do |suite_or_spec|
         type = suite_or_spec["type"]
         if type == "suite"
-          process_children(parent.describe(suite_or_spec["name"]), suite_or_spec["children"])
+          grand_parent_and_parent = example_group(parent.description + " " + suite_or_spec["name"]) {}
+          process_children(grand_parent_and_parent, suite_or_spec["children"])
         elsif type == "spec"
           declare_spec(parent, suite_or_spec)
         else


### PR DESCRIPTION
There is a bug where a nested test will have several describes/context in the row. When forming the full name of the test after a failure, the name of the test can get truncated in the middle because the new parent (describe) name overwrites the old one

Example being (in rspec)

describe "foo"
  describe "bar"
    it "is"

When searching for the test by name, the search string ends up being "bar is" and not "foo bar is" which makes locating the test location that much more difficult when building a stack trace
