### PR TITLE
For now, return a non-zero status from run_specs on failure

### DIFF
--- a/lib/jasmine/run_specs.rb
+++ b/lib/jasmine/run_specs.rb
@@ -30,3 +30,4 @@ config.formatters.each do |formatter_class|
   formatter.format()
 end
 
+exit 1 if results.failures.present?


### PR DESCRIPTION
That way, rake jasmine:ci will fail when there are errors. As per #163 there still aren't proper RSpec examples, but at least there won't be false positives anymore.
