### PR TITLE
Ensure IE compatibility mode is disabled

### DIFF
--- a/lib/jasmine/run.html.erb
+++ b/lib/jasmine/run.html.erb
@@ -2,6 +2,7 @@
 <html xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta content="text/html;charset=UTF-8" http-equiv="Content-Type"/>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <title>Jasmine suite</title>
   <link rel="shortcut icon" type="image/png" href="/__images__/jasmine_favicon.png">
   <% css_files.each do |css_file| %>


### PR DESCRIPTION
We've decided to use IE=edge for IE compatibility because this will put IE into the highest available mode for each version of IE.

See: http://stackoverflow.com/questions/3449286/force-ie-compatibility-mode-off-in-ie-using-tags

Seems like a good idea to run Jasmine tests in the highest mode available. (IE 9 should run in IE9 mode, not IE8 compat mode)

Fixes the following error on IE8 when running jasmine:

```
Object doesn't support this property or method  jasmine-html.js, line 229 character 7
>> getContainer().querySelector
undefined
```

fixes pivotal/jasmine#417
