### PR TITLE
Fixing check for whether Rails app is using asset pipeline.

### DIFF
--- a/lib/jasmine/dependencies.rb
+++ b/lib/jasmine/dependencies.rb
@@ -23,7 +23,9 @@ module Jasmine
       end
 
       def use_asset_pipeline?
-        (rails3? || rails4?) && Rails.respond_to?(:application) && Rails.application.respond_to?(:assets)
+        assets_pipeline_available = (rails3? || rails4?) && Rails.respond_to?(:application) && Rails.application.respond_to?(:assets)
+        rails3_assets_enabled = rails3? && assets_pipeline_available && Rails.application.config.assets.enabled != false
+        assets_pipeline_available && (rails4? || rails3_assets_enabled)
       end
 
       private


### PR DESCRIPTION
This modification was necessary for a rails app that has `config.assets.enabled = false` in config/application.rb.

Note that there's another way in which the revised check is not strictly equivalent to the earlier one: the revised version will return true if anything in the chain returns `nil`. I think this is fine, since Rails.application.assets should be truthy by default, afaik, but I could be wrong.
