### PR TITLE
rvm does not have 'rbx-XYZ-mode' anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - "1.9.3"
   - "2.0.0"
   - "jruby"
-  - "rbx-19mode"
+  - "rbx-2"
 
 env:
  - "RAILS_VERSION=rails3"


### PR DESCRIPTION
Builds are failing on Travis CI because it cannot install this version. Unfortunately, it looks like you can't install 1.9.x versions of rubinius through rvm.

More info available at https://github.com/travis-ci/travis-ci/issues/1641
