### PR TITLE
Sort of fix undefined method or local variable "assets_environment "

### DIFF
--- a/lib/jasmine/asset_bundle.rb
+++ b/lib/jasmine/asset_bundle.rb
@@ -49,7 +49,7 @@ module Jasmine
         @context = ActionView::Base.new
         @context.instance_eval do
           def get_original_assets(pathname)
-            assets_environment.find_asset(pathname).to_a.map do |processed_asset|
+            Rails.application.assets.find_asset(pathname).to_a.map do |processed_asset|
               case processed_asset.content_type
               when "text/css"
                 path_to_stylesheet(processed_asset.logical_path)


### PR DESCRIPTION
I stumbled upon the same error as referenced in this issue https://github.com/pivotal/jasmine-gem/issues/184 within a rails 4.0.2 application.
It seems that the integration with https://github.com/rails/sprockets-rails/ is somehow broken.
Looks like this block https://github.com/rails/sprockets-rails/blob/master/lib/sprockets/railtie.rb#L64-L125 never runs and therefore `assets_environment` never get set.

This is of course by no mean a proper fix, just a quick insight of my investigations.

here is the stacktrace

```
± % rake jasmine:ci                                                                                                                                                                                   !2007
(in /Users/ymarquet/moneyadvice/mas-development_dependencies/spec/dummy)
[2014-01-07 17:14:47] INFO  WEBrick 1.3.1
[2014-01-07 17:14:47] INFO  ruby 2.0.0 (2013-11-22) [x86_64-darwin12.5.0]
[2014-01-07 17:14:47] INFO  WEBrick::HTTPServer#start: pid=77147 port=49326
Waiting for jasmine server on 49326...
jasmine server started.
2014-01-07 17:14:49.113 phantomjs[77210:f07] *** WARNING: Method userSpaceScaleFactor in class NSView is deprecated on 10.7 and later. It should not be used in new applications. Use convertRectToBacking: instead.
[2014-01-07 17:14:49] ERROR NameError: undefined local variable or method `assets_environment' for #<ActionView::Base:0x007fc69b660968>
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/jasmine-2.0.0/lib/jasmine/asset_bundle.rb:53:in `get_original_assets'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/jasmine-2.0.0/lib/jasmine/asset_bundle.rb:43:in `assets'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/jasmine-2.0.0/lib/jasmine/asset_expander.rb:10:in `expand'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/jasmine-2.0.0/lib/jasmine/asset_pipeline_mapper.rb:11:in `call'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/jasmine-2.0.0/lib/jasmine/asset_pipeline_mapper.rb:11:in `block in map_src_paths'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/jasmine-2.0.0/lib/jasmine/asset_pipeline_mapper.rb:10:in `map'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/jasmine-2.0.0/lib/jasmine/asset_pipeline_mapper.rb:10:in `map_src_paths'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/jasmine-2.0.0/lib/jasmine/configuration.rb:86:in `block in map'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/jasmine-2.0.0/lib/jasmine/configuration.rb:84:in `each'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/jasmine-2.0.0/lib/jasmine/configuration.rb:84:in `inject'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/jasmine-2.0.0/lib/jasmine/configuration.rb:84:in `map'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/jasmine-2.0.0/lib/jasmine/configuration.rb:37:in `js_files'
    (erb):11:in `block in render'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/erb.rb:849:in `eval'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/erb.rb:849:in `result'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/jasmine-2.0.0/lib/jasmine/page.rb:8:in `render'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/jasmine-2.0.0/lib/rack/jasmine/runner.rb:15:in `call'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rack-1.5.2/lib/rack/cascade.rb:33:in `block in call'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rack-1.5.2/lib/rack/cascade.rb:24:in `each'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rack-1.5.2/lib/rack/cascade.rb:24:in `call'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rack-1.5.2/lib/rack/urlmap.rb:65:in `block in call'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `each'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `call'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/jasmine-2.0.0/lib/rack/jasmine/cache_control.rb:10:in `call'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rack-1.5.2/lib/rack/head.rb:11:in `call'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rack-1.5.2/lib/rack/handler/webrick.rb:60:in `service'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/webrick/httpserver.rb:138:in `service'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/webrick/httpserver.rb:94:in `run'
    /Users/ymarquet/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/webrick/server.rb:295:in `block in start_thread'
```
