### PR TITLE
move spec files to before end of body tag

### DIFF
--- a/lib/jasmine/run.html.erb
+++ b/lib/jasmine/run.html.erb
@@ -8,13 +8,12 @@
   <% css_files.each do |css_file| %>
     <link rel="stylesheet" href="<%= css_file %>" type="text/css" media="screen"/>
   <% end %>
-  <% js_files.each do |js_file| %>
-  <script src="<%= js_file %>" type="text/javascript"></script>
-  <% end %>
-
 </head>
 <!-- TODO: turbolinks breaks spec filter links -->
 <body data-no-turbolink>
 <div id="jasmine_content"></div>
+  <% js_files.each do |js_file| %>
+    <script src="<%= js_file %>" type="text/javascript"></script>
+  <% end %>
 </body>
 </html>


### PR DESCRIPTION
This speeds up the loading of the page a bit and also follows convention that most sites are using now.
