### PR TITLE
fixes #202: changing phantom_boot.js to use jsApiReporter

### DIFF
--- a/lib/jasmine/runners/phantom_boot.js
+++ b/lib/jasmine/runners/phantom_boot.js
@@ -1,11 +1,7 @@
-function PhantomReporter() {
-  this.jasmineDone = function() {
-    window.callPhantom({ state: 'jasmineDone'  });
-  };
-
-  this.specDone = function(results) {
-    window.callPhantom({ state: 'specDone', results: results});
-  };
+jsApiReporter.jasmineDone = function () {
+  window.callPhantom({state: 'jasmineDone'});
 }
 
-jasmine.getEnv().addReporter(new PhantomReporter());
+jsApiReporter.specDone = function (results) {
+  window.callPhantom({state: 'specDone', results: results});
+}


### PR DESCRIPTION
The reason the jasmine:ci task was stalling for me in #202 is I'm using a modified boot js to run jasmine with requirejs. Thus, the phantom_boot file couldn't find `jasmine` at runtime because it was being loaded asynchronously, so the reporter was never added and phantomjs was never called.

I've replaced the PhantomReporter with the appropriate hooks into the `jsApiReporter`. This seems to be the intended use case, and since it's exposed in the `jasmineInterface` and added as a reporter in the jasmine environment by default this seems like the best solution.
