### PR TITLE
Allow prevention of automatic PhantomJS download

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -43,7 +43,7 @@ For Continuous Integration environments, add this task to the project build step
 
 This uses PhantomJS to load and run the Jasmine suite. 
 
-Please note that PhantomJS will be auto-installed by the [phantomjs-gem][phantomjs-gem] at the first `rake jasmine:ci` run. If you have a PhantomJS somewhere on your path, it won't install.
+Please note that PhantomJS will be auto-installed by the [phantomjs-gem][phantomjs-gem] at the first `rake jasmine:ci` run. If you have a matching PhantomJS version somewhere on your path, it won't install. You can disable automatic installation altogether (and use the PhantomJS on your path) via the config helper.
 
 [phantomjs-gem]: https://github.com/colszowka/phantomjs-gem#phantomjs-as-a-rubygem
 

--- a/lib/generators/jasmine/install/templates/spec/javascripts/support/jasmine_helper.rb
+++ b/lib/generators/jasmine/install/templates/spec/javascripts/support/jasmine_helper.rb
@@ -8,4 +8,8 @@
 #   config.boot_files = lambda { ['/absolute/path/to/boot_dir/file.js'] }
 #end
 #
-
+#Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
+#Jasmine.configure do |config|
+#   config.prevent_phantomjs_auto_install = true
+#end
+#

--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -73,7 +73,7 @@ module Jasmine
       })
     end
 
-    @config.runner = lambda { |formatter, jasmine_server_url| Jasmine::Runners::PhantomJs.new(formatter, jasmine_server_url, 50) }
+    @config.runner = lambda { |formatter, jasmine_server_url| Jasmine::Runners::PhantomJs.new(formatter, jasmine_server_url, 50, @config.prevent_phantom_js_auto_install) }
   end
 
   def self.config

--- a/lib/jasmine/configuration.rb
+++ b/lib/jasmine/configuration.rb
@@ -9,6 +9,7 @@ module Jasmine
     attr_accessor :spec_format
     attr_accessor :runner
     attr_accessor :rack_options
+    attr_accessor :prevent_phantom_js_auto_install
     attr_reader :rack_apps
 
     def initialize()

--- a/lib/jasmine/runners/phantom_js.rb
+++ b/lib/jasmine/runners/phantom_js.rb
@@ -3,14 +3,15 @@ require 'phantomjs'
 module Jasmine
   module Runners
     class PhantomJs
-      def initialize(formatter, jasmine_server_url, result_batch_size)
+      def initialize(formatter, jasmine_server_url, result_batch_size, prevent_phantom_js_auto_install)
         @formatter = formatter
         @jasmine_server_url = jasmine_server_url
         @result_batch_size = result_batch_size
+        @prevent_phantom_js_auto_install = prevent_phantom_js_auto_install
       end
 
       def run
-        command = "#{Phantomjs.path} '#{File.join(File.dirname(__FILE__), 'phantom_jasmine_run.js')}' #{jasmine_server_url} #{result_batch_size}"
+        command = "#{phantom_js_path} '#{File.join(File.dirname(__FILE__), 'phantom_jasmine_run.js')}' #{jasmine_server_url} #{result_batch_size}"
         IO.popen(command) do |output|
           output.each do |line|
             if line =~ /^jasmine_result/
@@ -24,12 +25,16 @@ module Jasmine
         formatter.done
       end
 
+      def phantom_js_path
+        prevent_phantom_js_auto_install ? 'phantomjs' : Phantomjs.path
+      end
+
       def boot_js
         File.expand_path('phantom_boot.js', File.dirname(__FILE__))
       end
 
       private
-      attr_reader :formatter, :jasmine_server_url, :result_batch_size
+      attr_reader :formatter, :jasmine_server_url, :result_batch_size, :prevent_phantom_js_auto_install
     end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -141,6 +141,14 @@ describe Jasmine::Configuration do
     end
   end
 
+  describe 'prevent phantomjs auto install' do
+    it 'returns value if set' do
+      config = Jasmine::Configuration.new()
+      config.prevent_phantom_js_auto_install = true
+      config.prevent_phantom_js_auto_install.should == true
+    end
+  end
+
   describe 'jasmine ports' do
     it 'returns new CI port and caches return value' do
       config = Jasmine::Configuration.new()


### PR DESCRIPTION
- Allow users to purposefully avoid automatic download and installation
  of PhantomJS using configuration
- Maintains default behaviour of downloading if unavailable
- The download and installation is over http and without a checksum, which poses a security risk
- When preventing download, PhantomJS already on the path is used
- Includes an example in the generated jasmine helper
- Readme also updated for clarification
