### PR TITLE
Fix config option typo in jasmine helper

### DIFF
--- a/lib/generators/jasmine/install/templates/spec/javascripts/support/jasmine_helper.rb
+++ b/lib/generators/jasmine/install/templates/spec/javascripts/support/jasmine_helper.rb
@@ -10,6 +10,6 @@
 #
 #Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
 #Jasmine.configure do |config|
-#   config.prevent_phantomjs_auto_install = true
+#   config.prevent_phantom_js_auto_install = true
 #end
 #


### PR DESCRIPTION
- The actual config option contains an extra underscore.
