### PR TITLE
Display separate commands on separate lines in the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,13 +21,15 @@ end
 
 To initialize a project for Jasmine
 
-`rails g jasmine:install`
-`rails g jasmine:examples`
+    rails g jasmine:install
+
+    rails g jasmine:examples
 
 For any other project (Sinatra, Merb, or something we don't yet know about) use
 
-`jasmine init`
-`jasmine examples`
+    jasmine init
+
+    jasmine examples
 
 ## Usage
 


### PR DESCRIPTION
I found it confusing that these two pairs of commands appear on a single line
when viewed on GitHub.
