### PR TITLE
Catching error when ipv6 is off

### DIFF
--- a/lib/jasmine/base.rb
+++ b/lib/jasmine/base.rb
@@ -23,7 +23,7 @@ module Jasmine
     require 'socket'
     begin
       socket = TCPSocket.open(hostname, port)
-    rescue Errno::ECONNREFUSED, Errno::ENETUNREACH
+    rescue Errno::ECONNREFUSED, Errno::ENETUNREACH, Errno::EAFNOSUPPORT
       return false
     end
     socket.close


### PR DESCRIPTION
bash-4.1# bundle exec rake jasmine:ci --trace
*\* Invoke jasmine:ci (first_time)
*\* Invoke jasmine:require_json (first_time)
*\* Execute jasmine:require_json
*\* Invoke jasmine:require (first_time)
*\* Invoke environment (first_time)
*\* Execute environment
*\* Invoke jasmine_junitxml_formatter:setup (first_time)
*\* Execute jasmine_junitxml_formatter:setup
*\* Execute jasmine:require
*\* Invoke jasmine:configure (first_time)
*\* Execute jasmine:configure
*\* Invoke jasmine:configure_plugins (first_time)
*\* Execute jasmine:configure_plugins
*\* Execute jasmine:ci
rake aborted!
Errno::EAFNOSUPPORT: Address family not supported by protocol - socket(2)
