### PR TITLE
Result.rb line 34 blows up if attrs['failedExpectations'] is nil

### DIFF
--- a/lib/jasmine/result.rb
+++ b/lib/jasmine/result.rb
@@ -9,7 +9,7 @@ module Jasmine
       @status = attrs["status"]
       @full_name = attrs["fullName"]
       @description = attrs["description"]
-      @failed_expectations = map_failures(attrs["failedExpectations"])
+      @failed_expectations = map_failures(attrs["failedExpectations"]) unless attrs["failedExpectations"].nil?
       @suite_name = full_name.slice(0, full_name.size - description.size - 1)
     end
 


### PR DESCRIPTION
fix an issue where map failures blows up if attrs[failedExpectations] is...