### PR TITLE
Check the railties dependencies instead of rails dependencies

### DIFF
--- a/lib/jasmine/dependencies.rb
+++ b/lib/jasmine/dependencies.rb
@@ -3,11 +3,11 @@ module Jasmine
 
     class << self
       def rails3?
-        safe_gem_check("rails", "~> 3") && running_rails3?
+        safe_gem_check("railties", "~> 3") && running_rails3?
       end
 
       def rails4?
-        safe_gem_check("rails", "~> 4") && running_rails4?
+        safe_gem_check("railties", "~> 4") && running_rails4?
       end
 
       def rails?
@@ -15,7 +15,7 @@ module Jasmine
       end
 
       def rails_available?
-        safe_gem_check("rails", '>= 3')
+        safe_gem_check("railties", '>= 3')
       end
 
       def legacy_rack?


### PR DESCRIPTION
To know if the project use rails. Test the railties gem instead of rails gem.

I use a rails project without rails dependencies to avoid the Activerecord gem dependencies. My project is a full rails application. but jasmine don't think it is. It's better to check the railties gem to know if the project is a rails project or not.
