### PR TITLE
Add the configuration option to show a full stack trace

### DIFF
--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -79,7 +79,8 @@ module Jasmine
                                       jasmine_server_url,
                                       @config.prevent_phantom_js_auto_install,
                                       @config.show_console_log,
-                                      @config.phantom_config_script)
+                                      @config.phantom_config_script,
+                                      @config.show_full_stack_trace)
     end
   end
 

--- a/lib/jasmine/configuration.rb
+++ b/lib/jasmine/configuration.rb
@@ -12,6 +12,7 @@ module Jasmine
     attr_accessor :prevent_phantom_js_auto_install
     attr_accessor :show_console_log
     attr_accessor :phantom_config_script
+    attr_accessor :show_full_stack_trace
     attr_reader :rack_apps
 
     def initialize()

--- a/lib/jasmine/result.rb
+++ b/lib/jasmine/result.rb
@@ -6,6 +6,7 @@ module Jasmine
     end
 
     def initialize(attrs)
+      @show_full_stack_trace = attrs["show_full_stack_trace"]
       @status = attrs["status"]
       @full_name = attrs["fullName"]
       @description = attrs["description"]
@@ -28,16 +29,21 @@ module Jasmine
     attr_reader :full_name, :description, :failed_expectations, :suite_name
 
     private
-    attr_reader :status
+    attr_reader :status, :show_full_stack_trace
 
     def map_failures(failures)
       failures.map do |e|
-        short_stack = if e["stack"]
-                        e["stack"].split("\n").slice(0, 7).join("\n")
-                      else
-                        "No stack trace present."
-                      end
-        Failure.new(e["message"], short_stack)
+        if e["stack"]
+          if show_full_stack_trace
+            stack = e["stack"]
+          else
+            stack = e["stack"].split("\n").slice(0, 7).join("\n")
+          end
+        else
+          stack = "No stack trace present."
+        end
+
+        Failure.new(e["message"], stack)
       end
     end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -149,6 +149,14 @@ describe Jasmine::Configuration do
     end
   end
 
+  describe 'show full stack trace' do
+    it 'returns value if set' do
+      config = Jasmine::Configuration.new()
+      config.show_full_stack_trace = true
+      config.show_full_stack_trace.should == true
+    end
+  end
+
   describe 'jasmine ports' do
     it 'returns new CI port and caches return value' do
       config = Jasmine::Configuration.new()

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -21,6 +21,16 @@ describe Jasmine::Result do
       expectation.should_not match(/9/)
     end
 
+    it "exposes the full stack trace when configured" do
+      stack_trace = "1\n2\n3\n4\n5\n6\n7\n8\n9"
+      raw_result = failing_raw_result
+      raw_result["failedExpectations"][0]["stack"] = stack_trace
+
+      result = Jasmine::Result.new(raw_result.merge!("show_full_stack_trace" => true))
+      expectation = result.failed_expectations[0].stack
+      expectation.should == stack_trace
+    end
+
     it "handles failed specs with no stack trace" do
       raw_result = failing_result_no_stack_trace
 


### PR DESCRIPTION
I want to add the ability to configure jasmine to show the full stack trace when running with phantomjs in the console. The short, 7 line, stack trace is not long enough to show information from files in your code. It only contains stack information from the jasmine framework.

Here is a basic example:
```javascript
it('shows a stack trace', function() {
  var foo = true;
  var bar = false;

  expect(foo).toEqual(bar);
});
```
Console output:
```
jasmine server started.
F
          Jasmine__TopLevel__Suite shows a stack trace

          Expected true to equal false.
          Error: Expected true to equal false.
    at stack (http://localhost:8887/__jasmine__/jasmine.js:1439)
    at buildExpectationResult (http://localhost:8887/__jasmine__/jasmine.js:1416)
    at http://localhost:8887/__jasmine__/jasmine.js:533
    at http://localhost:8887/__jasmine__/jasmine.js:293
    at addExpectationResult (http://localhost:8887/__jasmine__/jasmine.js:477)
    at http://localhost:8887/__jasmine__/jasmine.js:1375
1 spec, 1 failure
```