### PR TITLE
Configure assets mode

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -81,6 +81,18 @@ In your jasmine_helper.rb:
        config.ci_port = 1234
     end
 
+### Asset concatenation
+
+By default, assets will be served up as single files, which aids debugging and makes stack traces more useful. For
+very large apps with thousands of files, concatenating all the files into a single application.js may speed the
+tests up.
+
+To configure this, in your jasmine_helper.rb:
+
+    Jasmine.configure do |config|
+      config.debug = false
+    end
+
 ## Support
 
 Jasmine Mailing list: [jasmine-js@googlegroups.com](mailto:jasmine-js@googlegroups.com)

--- a/README.markdown
+++ b/README.markdown
@@ -90,7 +90,7 @@ tests up.
 To configure this, in your jasmine_helper.rb:
 
     Jasmine.configure do |config|
-      config.debug = false
+      config.concatenate_assets = true
     end
 
 ## Support

--- a/lib/generators/jasmine/install/templates/spec/javascripts/support/jasmine_helper.rb
+++ b/lib/generators/jasmine/install/templates/spec/javascripts/support/jasmine_helper.rb
@@ -13,3 +13,8 @@
 #   config.prevent_phantom_js_auto_install = true
 #end
 #
+#Example: concatenate application assets into a single file.
+#Jasmine.configure do |config|
+#   config.debug = false
+#end
+#

--- a/lib/generators/jasmine/install/templates/spec/javascripts/support/jasmine_helper.rb
+++ b/lib/generators/jasmine/install/templates/spec/javascripts/support/jasmine_helper.rb
@@ -15,6 +15,6 @@
 #
 #Example: concatenate application assets into a single file.
 #Jasmine.configure do |config|
-#   config.debug = false
+#   config.concatenate_assets = true
 #end
 #

--- a/lib/jasmine/asset_expander.rb
+++ b/lib/jasmine/asset_expander.rb
@@ -1,9 +1,9 @@
 module Jasmine
   class AssetExpander
-    def expand(src_dir, src_path)
+    def expand(src_dir, src_path, debug_mode)
       pathname = src_path.gsub(/^\/?assets\//, '').gsub(/\.js$/, '')
 
-      asset_bundle.assets(pathname).flat_map { |asset|
+      asset_bundle(debug_mode).assets(pathname).flat_map { |asset|
         "/#{asset.gsub(/^\//, '')}?body=true"
       }
     end
@@ -12,9 +12,9 @@ module Jasmine
 
     UnsupportedRailsVersion = Class.new(StandardError)
 
-    def asset_bundle
+    def asset_bundle(debug_mode)
       return Rails3AssetBundle.new if Jasmine::Dependencies.rails3?
-      return Rails4AssetBundle.new if Jasmine::Dependencies.rails4?
+      return Rails4AssetBundle.new(debug_mode) if Jasmine::Dependencies.rails4?
       raise UnsupportedRailsVersion, "Jasmine only supports the asset pipeline for Rails 3 or 4"
     end
 
@@ -39,6 +39,10 @@ module Jasmine
     end
 
     class Rails4AssetBundle
+      def initialize(debug_mode)
+        @debug_mode = debug_mode
+      end
+
       def assets(pathname)
         context.get_original_assets(pathname)
       end
@@ -54,9 +58,9 @@ module Jasmine
           assets_environment.find_asset(pathname).to_a.map do |processed_asset|
             case processed_asset.content_type
             when "text/css"
-              path_to_stylesheet(processed_asset.logical_path, debug: true)
+              path_to_stylesheet(processed_asset.logical_path, debug: @debug_mode)
             when "application/javascript"
-              path_to_javascript(processed_asset.logical_path, debug: true)
+              path_to_javascript(processed_asset.logical_path, debug: @debug_mode)
             end
           end
         end

--- a/lib/jasmine/asset_pipeline_mapper.rb
+++ b/lib/jasmine/asset_pipeline_mapper.rb
@@ -8,7 +8,7 @@ module Jasmine
 
     def map_src_paths(src_paths)
       src_paths.map do |src_path|
-        expanded_assets = @asset_expander.call(@config.src_dir, src_path)
+        expanded_assets = @asset_expander.call(@config.src_dir, src_path, @config.debug)
         expanded_assets.empty? ? src_path : expanded_assets
       end.flatten.uniq
     end

--- a/lib/jasmine/asset_pipeline_mapper.rb
+++ b/lib/jasmine/asset_pipeline_mapper.rb
@@ -8,7 +8,7 @@ module Jasmine
 
     def map_src_paths(src_paths)
       src_paths.map do |src_path|
-        expanded_assets = @asset_expander.call(@config.src_dir, src_path, @config.debug)
+        expanded_assets = @asset_expander.call(@config.src_dir, src_path, @config.concatenate_assets)
         expanded_assets.empty? ? src_path : expanded_assets
       end.flatten.uniq
     end

--- a/lib/jasmine/configuration.rb
+++ b/lib/jasmine/configuration.rb
@@ -14,6 +14,7 @@ module Jasmine
     attr_accessor :stop_spec_on_expectation_failure
     attr_accessor :phantom_config_script
     attr_accessor :show_full_stack_trace
+    attr_accessor :debug
     attr_reader :rack_apps
 
     def initialize()
@@ -32,6 +33,7 @@ module Jasmine
       @show_console_log = false
       @stop_spec_on_expectation_failure = false
       @phantom_config_script = nil
+      @debug = true
 
       @formatters = [Jasmine::Formatters::Console]
 

--- a/lib/jasmine/configuration.rb
+++ b/lib/jasmine/configuration.rb
@@ -14,7 +14,7 @@ module Jasmine
     attr_accessor :stop_spec_on_expectation_failure
     attr_accessor :phantom_config_script
     attr_accessor :show_full_stack_trace
-    attr_accessor :debug
+    attr_accessor :concatenate_assets
     attr_reader :rack_apps
 
     def initialize()
@@ -33,7 +33,7 @@ module Jasmine
       @show_console_log = false
       @stop_spec_on_expectation_failure = false
       @phantom_config_script = nil
-      @debug = true
+      @concatenate_assets = false
 
       @formatters = [Jasmine::Formatters::Console]
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -213,5 +213,16 @@ describe Jasmine::Configuration do
       config.runner.call('hi')
     end
   end
-end
 
+  describe 'debug' do
+    it 'is true by default' do
+      Jasmine::Configuration.new.debug.should == true
+    end
+
+    it 'can be set' do
+      config = Jasmine::Configuration.new
+      config.debug = false
+      config.debug.should == false
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -214,15 +214,15 @@ describe Jasmine::Configuration do
     end
   end
 
-  describe 'debug' do
-    it 'is true by default' do
-      Jasmine::Configuration.new.debug.should == true
+  describe 'concatenate_assets' do
+    it 'is false by default' do
+      Jasmine::Configuration.new.concatenate_assets.should == false
     end
 
     it 'can be set' do
       config = Jasmine::Configuration.new
-      config.debug = false
-      config.debug.should == false
+      config.concatenate_assets = true
+      config.concatenate_assets.should == true
     end
   end
 end

--- a/spec/jasmine_rails_spec.rb
+++ b/spec/jasmine_rails_spec.rb
@@ -137,11 +137,11 @@ if Jasmine::Dependencies.rails?
       end
     end
 
-    it "bundles assets together when debug is set to false" do
+    it "bundles assets together when concatenate_assets is set to true" do
       asset_yaml = custom_jasmine_config('debug_mode') do |jasmine_config|
         jasmine_config['src_files'] = ['assets/application.js']
         jasmine_config['stylesheets'] = ['assets/application.css']
-        jasmine_config['debug'] = false
+        jasmine_config['concatenate_assets'] = true
       end
 
       run_jasmine_server("JASMINE_CONFIG_PATH=#{asset_yaml}") do

--- a/spec/jasmine_rails_spec.rb
+++ b/spec/jasmine_rails_spec.rb
@@ -137,6 +137,24 @@ if Jasmine::Dependencies.rails?
       end
     end
 
+    it "bundles assets together when debug is set to false" do
+      asset_yaml = custom_jasmine_config('debug_mode') do |jasmine_config|
+        jasmine_config['src_files'] = ['assets/application.js']
+        jasmine_config['stylesheets'] = ['assets/application.css']
+        jasmine_config['debug'] = false
+      end
+
+      run_jasmine_server("JASMINE_CONFIG_PATH=#{asset_yaml}") do
+        output = Net::HTTP.get(URI.parse('http://localhost:8888/'))
+        output.should_not match(%r{script src.*/assets/jasmine_examples/Player\.js})
+        output.should_not match(%r{script src.*/assets/jasmine_examples/Song\.js})
+        output.should match(%r{script src.*/assets/application\.js})
+
+        output = `bundle exec rake jasmine:ci`
+        output.should include('5 specs, 0 failures')
+      end
+    end
+
     it "sets assets_prefix when using sprockets" do
       open('app/assets/stylesheets/assets_prefix.js.erb', 'w') { |f|
         f.puts "<%= assets_prefix %>"


### PR DESCRIPTION
This PR adds the option for Jasmine to serve up a single application.js bundle instead of individual files.

See issue #240.

I've added some [rails integration tests](https://github.com/jasmine/jasmine-gem/blob/25659f3230e3c3fa3c280753f434f186b9d0fad7/spec/jasmine_rails_spec.rb#L140-156), but have been unable to actually run them. When I run `rake`, a 113 tests run (and pass), but these tests don't seem to run. Is there anything special I need to do to run them? I followed the `HOW_TO_TEST` instructions.

Currently, the AssetPipelineManager is [threading the debug option through](https://github.com/jasmine/jasmine-gem/blob/25659f3230e3c3fa3c280753f434f186b9d0fad7/lib/jasmine/asset_pipeline_mapper.rb#L11) to the AssetExpander's [rails4 integration](https://github.com/jasmine/jasmine-gem/blob/25659f3230e3c3fa3c280753f434f186b9d0fad7/lib/jasmine/asset_expander.rb#L60-63). I'm open to suggestions as to a better way if anyone has any thoughts.

Also, I really need a solution that will work with Rails 3, too. Any ideas? Kind of lost, here.