### PR TITLE
Add Host Support with Specs

### DIFF
--- a/lib/jasmine/server.rb
+++ b/lib/jasmine/server.rb
@@ -4,14 +4,15 @@ module Jasmine
       @port = port
       @application = application
       @rack_options = rack_options || {}
+      @host = rack_options[:Host] ? rack_options[:Host] : 'localhost' 
     end
 
     def start
       if Jasmine::Dependencies.legacy_rack?
         handler = Rack::Handler.get('webrick')
-        handler.run(@application, :Port => @port, :AccessLog => [])
+        handler.run(@application, :Port => @port, :AccessLog => [], :Host => @host)
       else
-        server = Rack::Server.new(@rack_options.merge(:Port => @port, :AccessLog => []))
+        server = Rack::Server.new(@rack_options.merge(:Port => @port, :AccessLog => [], :Host => @host))
         # workaround for Rack bug, when Rack > 1.2.1 is released Rack::Server.start(:app => Jasmine.app(self)) will work
         server.instance_variable_set(:@app, @application)
         server.start

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -30,6 +30,14 @@ describe Jasmine::Server do
       Jasmine::Server.new(port, double(:app)).start
     end
 
+    it "should create a Rack::Server with the correct host when passed" do
+      host = '0.0.0.0'
+      server = double(:server)
+      Rack::Server.should_receive(:new).with(hash_including(:host => host)).and_return(double(:server).as_null_object)
+      Jasmine::Server.new(1234, double(:app), {:Host => host}).start
+      server.instance_variable_get(:@host).should == host
+    end
+
     it "should start the server" do
       server = double(:server)
       Rack::Server.should_receive(:new) { server.as_null_object }


### PR DESCRIPTION
As I want to use the Jasmine Runner inside a VM.  I want to be able to pass the Host to the Server call and make it available from my host Server. 

The specs are locally not running without the changes, this pull request should just give you an idea of how it is supposed to work.

ruby 2.1.5p273 on Windows 7, 64-bit