### PR TITLE
Resolve problem with Phantom 2.0.0

### DIFF
--- a/HOW_TO_TEST.markdown
+++ b/HOW_TO_TEST.markdown
@@ -1,6 +1,6 @@
 To test changes to the jasmine-gem:
 
-* You need to have the [jasmine project](https://github.com/jasmine/jasmine) checked out in ../jasmine
+* You need to have the [jasmine project](https://github.com/jasmine/jasmine) checked out in `../jasmine`
 * Export RAILS_VERSION as either "pojs" (Plain Old JavaScript -- IE, no rails bindings), or "rails3" to test environments other than Rails 4.
 * Delete `Gemfile.lock`
 * Clear out your current gemset

--- a/HOW_TO_TEST.markdown
+++ b/HOW_TO_TEST.markdown
@@ -1,5 +1,6 @@
 To test changes to the jasmine-gem:
 
+* You need to have the [jasmine project](https://github.com/jasmine/jasmine) checked out in ../jasmine
 * Export RAILS_VERSION as either "pojs" (Plain Old JavaScript -- IE, no rails bindings), or "rails3" to test environments other than Rails 4.
 * Delete `Gemfile.lock`
 * Clear out your current gemset

--- a/lib/jasmine/runners/phantom_jasmine_run.js
+++ b/lib/jasmine/runners/phantom_jasmine_run.js
@@ -1,7 +1,17 @@
 (function() {
-  var url = phantom.args[0];
-  var showConsoleLog = phantom.args[1] === 'true';
-  var configScript = phantom.args[2];
+
+  if (phantom.version.major >= 2) {
+    var system = require('system');
+    var url = system.args[1];
+    var showConsoleLog = system.args[2] === 'true';
+    var configScript = system.args[3];
+  }
+  else {
+    var url = phantom.args[0];
+    var showConsoleLog = phantom.args[1] === 'true';
+    var configScript = phantom.args[2];
+  }
+
   var page = require('webpage').create();
 
   if (configScript !== '') {


### PR DESCRIPTION
As [reported](https://github.com/jasmine/jasmine-gem/issues/244), Jasmine currently hangs when run with Phantom 2.0.0, here's a patch to fix it. I tested this with Phantom 1.9.8, and then with Phantom 2.0.0, and everything passed.

The ['official' PhantomJS gem](https://github.com/colszowka/phantomjs-gem) has not updated to 2.0.0 yet, so to run the tests against 2.0.0 I added:
`gem 'phantomjs', :github => 'PatrickKing/phantomjs-gem'`
to the Gemfile, which points to a version of phantom that I have personally hacked together to get 2.0.0 into my own projects. You should probably not use this gem. I have not included this change in the pull request.



