### PR TITLE
Fix PathMapper overzealously replacing working directory

### DIFF
--- a/lib/jasmine/path_mapper.rb
+++ b/lib/jasmine/path_mapper.rb
@@ -30,7 +30,7 @@ module Jasmine
         if path[0..3] == 'http'
           path
         else
-          File.join(add_path, (path.gsub(remove_path, '')))
+          File.join(add_path, (path.sub(remove_path, '')))
         end
       end
     end

--- a/spec/path_mapper_spec.rb
+++ b/spec/path_mapper_spec.rb
@@ -30,4 +30,9 @@ describe Jasmine::PathMapper do
     mapper = Jasmine::PathMapper.new(config)
     mapper.map_src_paths(['/src_dir/foo']).should == ['/src_dir/foo']
   end
+  it 'handles edge case with multiple instances of src dir' do
+    config = double(:config, :src_dir => '/app', :src_path => '/')
+    mapper = Jasmine::PathMapper.new(config)
+    mapper.map_src_paths(['/app/assets/application.js']).should == ['/assets/application.js']
+  end
 end


### PR DESCRIPTION
When an asset's path (`/app/assets/application.js`) shares a
substring with the src_dir of an application (`/app`), the PathMapper
removes the src_dir too many times (`assetslication.js`).

This changes the gsub to a simple sub so that only the first occurrence
is modified.