### PR TITLE
Spec option

### DIFF
--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -108,7 +108,9 @@ module Jasmine
         config.css_files = lambda { yaml_config.css_files }
 
         config.spec_dir = yaml_config.spec_dir
-        config.spec_files = lambda { yaml_config.helpers + yaml_config.spec_files }
+        config.helper_files = yaml_config.helpers
+        config.spec_files =  yaml_config.spec_files
+        config.testing_files = lambda { config.helper_files + config.spec_files }
 
         config.show_console_log = yaml_config.show_console_log
         config.stop_spec_on_expectation_failure = yaml_config.stop_spec_on_expectation_failure
@@ -122,4 +124,10 @@ module Jasmine
     end
   end
 
+  def self.load_spec(spec_path)
+    return if spec_path.nil?
+    Jasmine.configure do |c|  
+      c.spec_files = [spec_path]
+    end
+  end
 end

--- a/lib/jasmine/configuration.rb
+++ b/lib/jasmine/configuration.rb
@@ -1,8 +1,9 @@
 module Jasmine
   class Configuration
     attr_writer :jasmine_css_files, :css_files
-    attr_writer :jasmine_files, :boot_files, :src_files, :spec_files, :runner_boot_files
-    attr_accessor :jasmine_path, :spec_path, :boot_path, :src_path, :image_path, :runner_boot_path
+    attr_writer :jasmine_files, :boot_files, :src_files, :runner_boot_files
+    attr_accessor :helper_files, :spec_files, :testing_files
+    attr_accessor :jasmine_path, :spec_path, :boot_path, :src_path, :image_path, :runner_boot_path, :helper_files
     attr_accessor :jasmine_dir, :spec_dir, :boot_dir, :src_dir, :images_dir, :runner_boot_dir
     attr_accessor :formatters
     attr_accessor :host
@@ -26,7 +27,7 @@ module Jasmine
       @boot_files = lambda { [] }
       @runner_boot_files = lambda { [] }
       @src_files = lambda { [] }
-      @spec_files = lambda { [] }
+      @testing_files = lambda { [] }
       @runner = lambda { |config| }
       @rack_options = {}
       @show_console_log = false
@@ -48,7 +49,7 @@ module Jasmine
         map(@boot_files, :boot) +
         map(@runner_boot_files, :runner_boot) +
         map(@src_files, :src) +
-        map(@spec_files, :spec)
+        map(@testing_files, :spec)
     end
 
     def rack_path_map

--- a/lib/jasmine/tasks/jasmine.rake
+++ b/lib/jasmine/tasks/jasmine.rake
@@ -10,7 +10,7 @@ once. This should be done for you automatically if you installed jasmine's rake 
 with either 'jasmine init' or 'rails g jasmine:install'.
 
 
-EOF
+  EOF
   raise Exception.new(message)
 end
 
@@ -20,6 +20,14 @@ namespace :jasmine do
 
     begin
       Jasmine.load_configuration_from_yaml(ENV['JASMINE_CONFIG_PATH'])
+      if ENV['spec']
+        spec_path = ENV['spec'].dup
+        if spec_path.include? "spec/javascripts/" # crappy hack to allow for bash tab completion
+          spec_path.slice! "spec/javascripts/" 
+        end
+        Jasmine.load_spec(spec_path)
+      end
+
     rescue Jasmine::ConfigNotFound => e
       puts e.message
       exit 1

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -11,4 +11,23 @@ describe Jasmine do
     File.should_receive(:expand_path) { |path| path }
     Jasmine.root('subdir1', 'subdir2').should == File.join('lib/jasmine', 'subdir1', 'subdir2')
   end
+  describe '#load_spec' do
+    it 'assigns the spec to the spec path' do
+      Jasmine.load_spec("spec/test")
+      Jasmine.config.spec_files.should == [ "spec/test" ]
+    end
+
+    it 'does not assign a spec path if passed a nil' do
+      Jasmine.load_spec("spec/test")
+      Jasmine.load_spec(nil)
+      Jasmine.config.spec_files.should == [ "spec/test" ]
+    end
+
+    it 'does not override nonspec files' do
+      Jasmine.config.helper_files = ["aaa"]
+      Jasmine.load_spec("spec/test")
+      Jasmine.config.spec_files.should == [ "spec/test" ]
+      Jasmine.config.helper_files.should == ["aaa"]
+    end
+  end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -70,7 +70,7 @@ describe Jasmine::Configuration do
       config.jasmine_files = lambda { %w(jasmine) }
       config.src_files = lambda  { %w(src) }
       config.boot_files = lambda { %w(boot) }
-      config.spec_files = lambda { %w(spec) }
+      config.testing_files = lambda { %w(spec) }
       config.js_files.should == %w(
         mapped_jasmine/jasmine/jasmine
         mapped_boot/boot/boot mapped_src/src/src


### PR DESCRIPTION
At my company we had so many jasmine specs that they'd take 20+ seconds to load before the test runner even started. For our recent hackathon I sketched up `spec` option, so you can do `rake jasmine:ci spec=foo/bar/blat_spec.js` to only load and run the specs you want to. This has made it a lot easier for us to BDD with jasmine, since instead of running a few thousand specs in a minute we just do six in a few seconds.

I checked the gem and saw issue #234 and figured it'd be good to throw this up as a PR. I don't think it's master-ready yet - it is a hackathon project, after all. But it might make a good launching point for developing the feature. Let's chat revisions!