### PR TITLE
Rails 5 support

### DIFF
--- a/lib/jasmine/asset_expander.rb
+++ b/lib/jasmine/asset_expander.rb
@@ -14,8 +14,8 @@ module Jasmine
 
     def asset_bundle
       return Rails3AssetBundle.new if Jasmine::Dependencies.rails3?
-      return Rails4AssetBundle.new if Jasmine::Dependencies.rails4?
-      raise UnsupportedRailsVersion, "Jasmine only supports the asset pipeline for Rails 3 or 4"
+      return Rails4Or5AssetBundle.new if Jasmine::Dependencies.rails4? || Jasmine::Dependencies.rails5?
+      raise UnsupportedRailsVersion, "Jasmine only supports the asset pipeline for Rails 3 - 5"
     end
 
     class Rails3AssetBundle
@@ -38,7 +38,7 @@ module Jasmine
       end
     end
 
-    class Rails4AssetBundle
+    class Rails4Or5AssetBundle
       def assets(pathname)
         context.get_original_assets(pathname)
       end
@@ -51,7 +51,7 @@ module Jasmine
 
       module GetOriginalAssetsHelper
         def get_original_assets(pathname)
-          assets_environment.find_asset(pathname).to_a.map do |processed_asset|
+          Array(assets_environment.find_asset(pathname)).map do |processed_asset|
             case processed_asset.content_type
             when "text/css"
               path_to_stylesheet(processed_asset.logical_path, debug: true)

--- a/lib/jasmine/dependencies.rb
+++ b/lib/jasmine/dependencies.rb
@@ -3,38 +3,29 @@ module Jasmine
 
     class << self
       def rails3?
-        running_rails3?
+        rails? && Rails.version.to_i == 3
       end
 
       def rails4?
-        running_rails4?
+        rails? && Rails.version.to_i == 4
+      end
+
+      def rails5?
+        rails? && Rails.version.to_i == 5
       end
 
       def rails?
-        running_rails?
+        defined?(Rails) && Rails.respond_to?(:version)
       end
+
       def legacy_rack?
         !defined?(Rack::Server)
       end
 
       def use_asset_pipeline?
-        assets_pipeline_available = (rails3? || rails4?) && Rails.respond_to?(:application) && Rails.application.respond_to?(:assets)
+        assets_pipeline_available = (rails3? || rails4? || rails5?) && Rails.respond_to?(:application) && Rails.application.respond_to?(:assets)
         rails3_assets_enabled = rails3? && assets_pipeline_available && Rails.application.config.assets.enabled != false
-        assets_pipeline_available && (rails4? || rails3_assets_enabled)
-      end
-
-      private
-
-      def running_rails3?
-        running_rails? && Rails.version.to_i == 3
-      end
-
-      def running_rails4?
-        running_rails? && Rails.version.to_i == 4
-      end
-
-      def running_rails?
-        defined?(Rails) && Rails.respond_to?(:version)
+        assets_pipeline_available && (rails4? || rails5? || rails3_assets_enabled)
       end
     end
   end


### PR DESCRIPTION
The only notable difference seems to be that
`assets_environment.find_asset(pathname)` always returns
a single asset instead of an array of assets.

Does not yet include Rails 5 in the test matrix because it's alpha