### PR TITLE
Make versions correct?

### DIFF
--- a/jasmine.gemspec
+++ b/jasmine.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '>= 2.5.0'
   s.add_development_dependency 'nokogiri'
 
-  s.add_dependency 'jasmine-core', '~> 2.4'
+  s.add_dependency 'jasmine-core', '>= 2.4.1'
   s.add_dependency 'rack', '>= 1.2.1'
   s.add_dependency 'rake'
   s.add_dependency 'phantomjs'

--- a/lib/jasmine/version.rb
+++ b/lib/jasmine/version.rb
@@ -1,3 +1,3 @@
 module Jasmine
-  VERSION = "2.4.0"
+  VERSION = "2.4.1"
 end


### PR DESCRIPTION
Hi,
The first change is about syncing versions of `jasmine-gem` and `jasmine-core`. I think, making versions equal may help to avoid this kind of frustration:
```
$ gem install jasmine
Fetching: phantomjs-1.9.8.0.gem (100%)
...
Successfully installed jasmine-2.4.0
3 gems installed
```
This has fetched the following:
```
$ gem list | grep jasmine
jasmine (2.4.0)
jasmine-core (2.4.1)
```
`bundler` has exactly the same behavior.

Second. I'm not sure about it. `~> 2.4` replaced by `>= 2.4.1` due to [this](https://github.com/jasmine/jasmine/releases/tag/v2.4.1). Is it reasonable to force a user to install version greater than `2.4.1` in order to avoid `2.4.0` which has breaking changes? 