### PR TITLE
use multiple spec files

### DIFF
--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -128,7 +128,7 @@ module Jasmine
   def self.load_spec(spec_path)
     return if spec_path.nil?
     Jasmine.configure do |c|  
-      c.spec_files = [spec_path]
+      c.spec_files = spec_path.split
     end
   end
 end

--- a/lib/jasmine/tasks/jasmine.rake
+++ b/lib/jasmine/tasks/jasmine.rake
@@ -44,10 +44,7 @@ namespace :jasmine do
   desc 'Run jasmine tests in a browser, random and seed override config'
   task :ci, [:random, :seed] => %w(jasmine:require_json jasmine:require jasmine:configure jasmine:configure_plugins) do |t, args|
     if ENV['spec']
-      spec_path = ENV['spec'].dup
-      if spec_path.include? "spec/javascripts/" # crappy hack to allow for bash tab completion
-        spec_path.slice! "spec/javascripts/"
-      end
+      spec_path = ENV['spec'].gsub("spec/javascripts/", "")
       Jasmine.load_spec(spec_path)
     end
 

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -29,5 +29,10 @@ describe Jasmine do
       Jasmine.config.spec_files.should == [ "spec/test" ]
       Jasmine.config.helper_files.should == ["aaa"]
     end
+
+    it "assigns multiple specs" do
+      Jasmine.load_spec("spec/test1 spec/test2")
+      Jasmine.config.spec_files.should == [ "spec/test1", "spec/test2" ]
+    end
   end
 end


### PR DESCRIPTION
Currently the jasmine gem can either run all specs or a single file. This change allows the gem to run the specs in several files at once.

To use:

`rake jasmine:ci spec="spec1 spec2 spec3 [...] specN"`