### PR TITLE
Fix for windows

### DIFF
--- a/lib/jasmine/runners/phantom_jasmine_run.js
+++ b/lib/jasmine/runners/phantom_jasmine_run.js
@@ -13,7 +13,7 @@
   }
 
   var page = require('webpage').create();
-  configScript = (configScript === "''" || configScript === "''" ? "" : configScript);
+  configScript = configScript.replace(/['"]{2}/,"");
   
   if (configScript !== '') {
     try {

--- a/lib/jasmine/runners/phantom_jasmine_run.js
+++ b/lib/jasmine/runners/phantom_jasmine_run.js
@@ -13,7 +13,8 @@
   }
 
   var page = require('webpage').create();
-
+  configScript = (configScript === "''" || configScript === "''" ? "" : configScript);
+  
   if (configScript !== '') {
     try {
       require(configScript).configure(page);

--- a/lib/jasmine/runners/phantom_js.rb
+++ b/lib/jasmine/runners/phantom_js.rb
@@ -14,7 +14,7 @@ module Jasmine
 
       def run
         phantom_script = File.join(File.dirname(__FILE__), 'phantom_jasmine_run.js')
-        command = "#{phantom_js_path} '#{phantom_script}' \"#{jasmine_server_url}\" #{show_console_log} '#{@phantom_config_script}'"
+        command = "\"#{phantom_js_path}\" \"#{phantom_script}\" \"#{jasmine_server_url}\" \"#{show_console_log}\" \"#{@phantom_config_script}\""
         run_details = { 'random' => false }
         IO.popen(command) do |output|
           output.each do |line|


### PR DESCRIPTION
1. On windows empty params equals two single quotes. They need to be deleted for proper working.
2. On windows wraping executions attribute with single quotes doesn't work. They should be replaced by " ". 