### PR TITLE
Add ability to adjust hostname on CI

### DIFF
--- a/lib/jasmine/base.rb
+++ b/lib/jasmine/base.rb
@@ -30,9 +30,9 @@ module Jasmine
     true
   end
 
-  def self.wait_for_listener(port, name = "required process", seconds_to_wait = 20)
+  def self.wait_for_listener(port, name = "required process", seconds_to_wait = 20, hostname = 'localhost')
     time_out_at = Time.now + seconds_to_wait
-    until server_is_listening_on "localhost", port
+    until server_is_listening_on hostname, port
       sleep 0.1
       puts "Waiting for #{name} on #{port}..."
       raise "#{name} didn't show up on port #{port} after #{seconds_to_wait} seconds." if Time.now > time_out_at

--- a/lib/jasmine/ci_runner.rb
+++ b/lib/jasmine/ci_runner.rb
@@ -31,7 +31,7 @@ module Jasmine
       end
       t.abort_on_exception = true
 
-      Jasmine::wait_for_listener(config.port(:ci), 'jasmine server')
+      Jasmine::wait_for_listener(config.port(:ci), 'jasmine server', 20, config.hostname)
       @outputter.puts 'jasmine server started'
 
       runner.run

--- a/lib/jasmine/configuration.rb
+++ b/lib/jasmine/configuration.rb
@@ -6,6 +6,7 @@ module Jasmine
     attr_accessor :jasmine_path, :spec_path, :boot_path, :src_path, :image_path, :runner_boot_path, :helper_files
     attr_accessor :jasmine_dir, :spec_dir, :boot_dir, :src_dir, :images_dir, :runner_boot_dir
     attr_accessor :formatters
+    attr_accessor :hostname
     attr_accessor :host
     attr_accessor :spec_format
     attr_accessor :runner
@@ -92,6 +93,10 @@ module Jasmine
 
     def host
       @host || 'http://localhost'
+    end
+
+    def hostname
+      @hostname || 'localhost'
     end
 
     private

--- a/spec/ci_runner_spec.rb
+++ b/spec/ci_runner_spec.rb
@@ -9,6 +9,7 @@ describe Jasmine::CiRunner do
            :runner => runner_factory,
            :formatters => [],
            :host => 'foo.bar.com',
+           :hostname => 'foo.bar.com',
            :port => '1234',
            :rack_options => 'rack options',
            :stop_spec_on_expectation_failure => false,
@@ -54,7 +55,7 @@ describe Jasmine::CiRunner do
     @thread_block.call
     expect(fake_server).to have_received(:start)
 
-    expect(Jasmine).to have_received(:wait_for_listener).with('1234', 'jasmine server')
+    expect(Jasmine).to have_received(:wait_for_listener).with('1234', 'jasmine server', 20, 'foo.bar.com')
 
     expect(runner).to have_received(:run)
   end


### PR DESCRIPTION
Hi there, apologies if this is totally the wrong way to submit something.  I'm just struggling with some really weird issues on travis CI - the travis folks suggested switching from localhost to 127.0.0.1 which I couldn't do with the existing config - so I forked and made this code.  

The error I've been struggling with is:

```
$ USE_JASMINE_RAKE=true bundle exec rake jasmine:ci
[2016-08-11 01:25:32] INFO  WEBrick 1.3.1
[2016-08-11 01:25:32] INFO  ruby 2.3.1 (2016-04-26) [x86_64-linux]
rake aborted!
Errno::EINVAL: Invalid argument - connect(2) for "localhost" port 59417
/home/travis/build/AgileVentures/LocalSupport/vendor/bundle/ruby/2.3.0/gems/jasmine-2.4.0/lib/jasmine/base.rb:25:in `initialize'
/home/travis/build/AgileVentures/LocalSupport/vendor/bundle/ruby/2.3.0/gems/jasmine-2.4.0/lib/jasmine/base.rb:25:in `open'
/home/travis/build/AgileVentures/LocalSupport/vendor/bundle/ruby/2.3.0/gems/jasmine-2.4.0/lib/jasmine/base.rb:25:in `server_is_listening_on'
/home/travis/build/AgileVentures/LocalSupport/vendor/bundle/ruby/2.3.0/gems/jasmine-2.4.0/lib/jasmine/base.rb:35:in `wait_for_listener'
/home/travis/build/AgileVentures/LocalSupport/vendor/bundle/ruby/2.3.0/gems/jasmine-2.4.0/lib/jasmine/ci_runner.rb:34:in `run'
/home/travis/build/AgileVentures/LocalSupport/vendor/bundle/ruby/2.3.0/gems/jasmine-2.4.0/lib/jasmine/tasks/jasmine.rake:47:in `block (2 levels) in <top (required)>'
/home/travis/build/AgileVentures/LocalSupport/vendor/bundle/ruby/2.3.0/gems/airbrake-5.4.4/lib/airbrake/rake/task_ext.rb:19:in `execute'
/home/travis/build/AgileVentures/LocalSupport/vendor/bundle/ruby/2.3.0/gems/rake-11.2.2/exe/rake:27:in `<top (required)>'
/home/travis/.rvm/gems/ruby-2.3.1@global/gems/bundler-1.12.5/lib/bundler/cli/exec.rb:63:in `load'
/home/travis/.rvm/gems/ruby-2.3.1@global/gems/bundler-1.12.5/lib/bundler/cli/exec.rb:63:in `kernel_load'
/home/travis/.rvm/gems/ruby-2.3.1@global/gems/bundler-1.12.5/lib/bundler/cli/exec.rb:24:in `run'
/home/travis/.rvm/gems/ruby-2.3.1@global/gems/bundler-1.12.5/lib/bundler/cli.rb:304:in `exec'
/home/travis/.rvm/gems/ruby-2.3.1@global/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/home/travis/.rvm/gems/ruby-2.3.1@global/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/home/travis/.rvm/gems/ruby-2.3.1@global/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
/home/travis/.rvm/gems/ruby-2.3.1@global/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
/home/travis/.rvm/gems/ruby-2.3.1@global/gems/bundler-1.12.5/lib/bundler/cli.rb:11:in `start'
/home/travis/.rvm/gems/ruby-2.3.1@global/gems/bundler-1.12.5/exe/bundle:27:in `block in <top (required)>'
/home/travis/.rvm/gems/ruby-2.3.1@global/gems/bundler-1.12.5/lib/bundler/friendly_errors.rb:98:in `with_friendly_errors'
/home/travis/.rvm/gems/ruby-2.3.1@global/gems/bundler-1.12.5/exe/bundle:19:in `<top (required)>'
/home/travis/.rvm/gems/ruby-2.3.1/bin/bundle:23:in `load'
/home/travis/.rvm/gems/ruby-2.3.1/bin/bundle:23:in `<main>'
/home/travis/.rvm/gems/ruby-2.3.1/bin/ruby_executable_hooks:15:in `eval'
/home/travis/.rvm/gems/ruby-2.3.1/bin/ruby_executable_hooks:15:in `<main>'
[2016-08-11 01:25:32] INFO  WEBrick::HTTPServer#start: pid=20244 port=59417
Tasks: TOP => jasmine:ci
(See full trace by running task with --trace)
[2016-08-11 01:25:32] INFO  going to shutdown ...
[2016-08-11 01:25:32] INFO  WEBrick::HTTPServer#start done.
```

You can see the full build here:

https://travis-ci.org/AgileVentures/LocalSupport/builds/151389370

I can't see any CONTRIBUTING.md on best practice for PRs, so I guess I'll get this in as an exploratory one ...

Apologies in advance if this is rude or the wrong way to make suggestions
