### PR TITLE
rake jasmine:ci - Fixed issue where spec path was incorrect when using an absolute path which contains spec/javascripts/

### DIFF
--- a/lib/jasmine/tasks/jasmine.rake
+++ b/lib/jasmine/tasks/jasmine.rake
@@ -46,7 +46,7 @@ namespace :jasmine do
     if ENV['spec']
       spec_path = ENV['spec'].dup
       if spec_path.include? "spec/javascripts/" # crappy hack to allow for bash tab completion
-        spec_path.slice! "spec/javascripts/"
+        spec_path = spec_path.split("spec/javascripts/").last
       end
       Jasmine.load_spec(spec_path)
     end


### PR DESCRIPTION
When running `rake jasmine:ci`, if using the `spec` environment variable with an absolute path that contains `spec/javascripts/` (eg: `rake jasmine:ci spec=/Users/joeyjojojr/project/spec/javascripts/tests.js`) it would cut out the `spec/javascripts/` part and try and run a nonexistent file (`/Users/joeyjojojr/project/tests.js`).

This PR fixes this so when specifying an absolute path that includes `spec/javascripts/` the file path is not mangled
