### PR TITLE
Disable Turbolinks 5

### DIFF
--- a/lib/jasmine/run.html.erb
+++ b/lib/jasmine/run.html.erb
@@ -14,7 +14,7 @@
 
 </head>
 <!-- TODO: turbolinks breaks spec filter links -->
-<body data-no-turbolink>
+<body data-no-turbolink data-turbolinks="false">
 <div id="jasmine_content"></div>
 </body>
 </html>


### PR DESCRIPTION
Turbolinks 5 changed the <body> attribute used to disable it on a page. This commit simply adds the new attribute to the <body> tag in the Jasmine runner so that filter links work with Turbolinks v5+.
