### PR TITLE
Add clear Jasmine config functionality

### DIFF
--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -131,4 +131,8 @@ module Jasmine
       c.spec_files = [spec_path]
     end
   end
+
+  def self.config=(config)
+    @config = nil
+  end
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -30,4 +30,13 @@ describe Jasmine do
       Jasmine.config.helper_files.should == ["aaa"]
     end
   end
+  describe '#config=' do
+    let(:config) { Jasmine.config }
+
+    it 'sets config instance variable' do
+      expect { Jasmine.config = nil }
+        .to change { Jasmine.instance_variable_get(:@config) }
+        .from(config).to(nil)
+    end
+  end
 end


### PR DESCRIPTION
We need to run jasmine specs multiple times in multiple engines, so it is needed to clear the Jasmine config each time to avoid mixing up engines configs.
Now we use `Jasmine.instance_variable_set(:@config, nil)`, but it doesn't feel well.