### PR TITLE
Better detection of disabled assets pipeline

### DIFF
--- a/lib/jasmine/dependencies.rb
+++ b/lib/jasmine/dependencies.rb
@@ -19,7 +19,7 @@ module Jasmine
       end
 
       def use_asset_pipeline?
-        assets_pipeline_available = (rails3? || rails4? || rails5?) && Rails.respond_to?(:application) && Rails.application.respond_to?(:assets)
+        assets_pipeline_available = (rails3? || rails4? || rails5?) && Rails.respond_to?(:application) && Rails.application.respond_to?(:assets) && !Rails.application.assets.nil?
         rails3_assets_enabled = rails3? && assets_pipeline_available && Rails.application.config.assets.enabled != false
         assets_pipeline_available && (rails4? || rails5? || rails3_assets_enabled)
       end


### PR DESCRIPTION
It's not enough to detect if `Rails.application.assets` exists.
With sprockets-3 at least, we're incorrectly determining if the asset pipeline is enabled:

```
irb(main):002:0> Jasmine::Dependencies.use_asset_pipeline?
=> true
irb(main):003:0> Rails.application.assets
=> nil
```