### PR TITLE
Add support for sprockets 4 and source maps

### DIFF
--- a/spec/jasmine_rails_spec.rb
+++ b/spec/jasmine_rails_spec.rb
@@ -181,6 +181,53 @@ if rails_available?
       end
     end
 
+    describe 'using sprockets 4' do
+      before :all do
+        FileUtils.cp('Gemfile', 'Gemfile-old')
+        FileUtils.rm 'Gemfile.lock'
+        
+        open('Gemfile', 'a') { |f|
+          f.puts "gem 'sprockets', '~> 4.0.0.beta6'"
+          f.flush
+        }
+        Bundler.with_clean_env do
+          bundle_install
+        end
+
+        FileUtils.mkdir_p('app/assets/config')
+
+        open('app/assets/config/manifest.js', 'w') { |f| 
+          f.puts "//= link application.js"
+          f.puts "//= link application.css"
+          f.flush
+        }
+      end
+
+      after :all do
+        FileUtils.mv 'Gemfile-old', 'Gemfile'
+        FileUtils.rm 'Gemfile.lock'
+        FileUtils.rm 'app/assets/config/manifest.js'
+        Bundler.with_clean_env do
+          bundle_install
+        end
+      end
+
+      it "serves source mapped assets" do
+        run_jasmine_server do
+          output = Net::HTTP.get(URI.parse('http://localhost:8888/'))
+
+          js_match = output.match %r{script src.*/(assets/application.debug-[^\.]+\.js)}
+
+          expect(js_match).to_not be_nil
+          expect(output).to match(%r{<link rel=.stylesheet.*?href=.*/assets/application.debug-[^\.]+\.css})
+
+          js_path = js_match[1]
+          output = Net::HTTP.get(URI.parse("http://localhost:8888/#{js_path}"))
+          expect(output).to match(%r{//# sourceMappingURL=.*\.map})
+        end
+      end
+    end
+
     def run_jasmine_server(options = "")
       Bundler.with_clean_env do
         begin

--- a/spec/jasmine_rails_spec.rb
+++ b/spec/jasmine_rails_spec.rb
@@ -124,11 +124,11 @@ if rails_available?
 
       run_jasmine_server("JASMINE_CONFIG_PATH=#{css_yaml}") do
         output = Net::HTTP.get(URI.parse('http://localhost:8888/'))
-        expect(output).to match(%r{script src.*/assets/jasmine_examples/Player\.js})
+        expect(output).to match(%r{script src.*/assets/jasmine_examples/Player(\.self-[^\.]+)?\.js})
         expect(output).to match(%r{script src=['"]http://ajax\.googleapis\.com/ajax/libs/jquery/1\.11\.0/jquery\.min\.js})
-        expect(output).to match(%r{script src.*/assets/jasmine_examples/Song\.js})
+        expect(output).to match(%r{script src.*/assets/jasmine_examples/Song(\.self-[^\.]+)?\.js})
         expect(output).to match(%r{script src.*angular_helper\.js})
-        expect(output).to match(%r{<link rel=.stylesheet.*?href=./assets/foo\.css\?.*?>})
+        expect(output).to match(%r{<link rel=.stylesheet.*?href=./assets/foo(\.self-[^\.]+)?\.css\?.*?>})
 
         output = Net::HTTP.get(URI.parse('http://localhost:8888/__spec__/helpers/angular_helper.js'))
         expect(output).to match(/angular\.mock/)
@@ -196,6 +196,7 @@ if rails_available?
             puts "someone else is running a server on port 8888"
             expect($?).to be_success
           end
+          yield
         ensure
           Process.kill(:SIGINT, pid)
           begin


### PR DESCRIPTION
This adds support for Sprockets 4 and subsequently source maps.

## Motivation
On large Rails JS codebases, the current strategy of loading each js file from the asset pipeline separately can be very time consuming.  On a project I'm working on with around ~1400 js files, the time to load the page before specs even begin executing is ~10-15s.  This was echoed by #240 and PR #241.  (It's also an issue that other jasmine/rails implementations struggle with https://github.com/searls/jasmine-rails/issues/148.)

## Solution
Rails has long had the `config.assets.debug = false` option, which causes your asset files to be concatenated in development, to workaround making _n_ requests for each asset in the `assets/` folder.  My initial approach was to introduce a similar configuration option into jasmine-gem, but I discovered quickly that you lose the usefulness of your stack trace when you concatenate your assets together for spec tests.  (The page does load _substantially_ faster though!)

After doing some research, I learned that Sprockets 4 was taking a [different approach](https://github.com/rails/sprockets/blob/master/UPGRADING.md) to asset concatenation - essentially removing the `config.assets.debug` option, because it _always_ concatenates assets.  Sprockets 4 additionally uses source maps to get the same individual file fidelity as the `debug` option, without incurring the cost of loading each file individually.

So, this PR introduces support for Sprockets 4, which supports source maps.  

(_Side Note:_ I'd still like to open another PR to add a config option that allows toggling of asset concatenation to provide those running older versions of rails a way to more speedily run their tests.)

## Details
I somewhat heavily modified the code in `asset_expander.rb` to more closely reflect what [sprockets-rails](https://github.com/rails/sprockets-rails/blob/master/lib/sprockets/rails/helper.rb#L142) does to resolve asset paths in the `javascript_include_tag` and `stylesheet_include_tag` helpers.  This seemed like a good decision for a couple of reasons:

1. Since sprockets-rails already has support for Sprockets 4, this made it easy to hook into the helpers they provide for serving up source mapped assets.
2. This way we're not reinventing the wheel when it comes to resolving assets because we can easily leverage the [somewhat complex](https://github.com/rails/sprockets-rails/blob/master/lib/sprockets/rails/helper.rb#L226) asset resolution code provided by `sprockets-rails`.

The sprockets-rails code also nicely degrades for older versions of sprockets, checking whether the asset `responds_to? :to_a` as a mechanism for determining sprockets version.  (`:to_a` was [removed](https://github.com/rails/sprockets/commit/5871589a967604142b1cf1a51850fdf4625b9269) in sprockets 4.)

## How it works

I've taken quite a few screenshots to illustrate how this all works.  I'd be up for writing some tests to validate this behavior, but I'm not 100% clear on the best way to branch the testing code (more on that later).

Here's what our assets look like before this PR is introduced while using Sprockets 4:
![sprockets-4-without-pr](https://user-images.githubusercontent.com/1121058/35761385-107bf074-0845-11e8-8df3-518d4395955c.png)

And after this PR is introduced - you'll can see the source files are notated as `.source.js`:
![sprockets-4-with-pr-source-maps](https://user-images.githubusercontent.com/1121058/35761400-39dbb472-0845-11e8-89ce-cdbf4a8652b3.png)

One downside I discovered right after doing this was that the native `Error.stack` that jasmine uses doesn't report locations with source maps, so you get just the concatenated asset:
![sprockets-4-stacktrace](https://user-images.githubusercontent.com/1121058/35761421-743d851e-0845-11e8-82e8-8d88912190d4.png)

As it turns out, there's an issue to track this on the core jasmine repo https://github.com/jasmine/jasmine/issues/491 but you _can_ work around that limitation by installing a helper_script that monkey patches `Error.stack` to look at source maps if present.  (One project that can help you do that is [node-source-map-support](https://github.com/evanw/node-source-map-support)).  After monkey patching, you get something like this 🙌 :

![sprockets4-stacktrace-sourcemaps](https://user-images.githubusercontent.com/1121058/35761461-f0e3cbf0-0845-11e8-999b-0e81cf221183.png)

(FWIW - I wouldn't normally advocate for monkey patching, but it does seem like the native `Error.stack` should be robust enough to support source maps.  I don't know if it should be Jasmine's responsibility to take care of it as an ExceptionFormatter - but either way, this absolutely works until a more permanent solution is found.)

## Testing

You can test this out by checking out the gem and creating a new rails project.  Modify the `Gemfile` to reference your local version of `jasmine-gem` and add `gem 'sprockets', github: 'rails/sprockets'` to get Sprockets 4.  After initializing jasmine in the repo, you should be able to run `rake jasmine` and see the source mapped files!

## Other changes
There were a couple of extra things I went ahead and fixed while I was in `asset_expander.rb` or the related spec.

**Double appended `body` query string param**
You have to append the `?body=true` query string parameter to get sprockets to serve the contents of the individual asset file, but starting with rails 4, this was always automatically appended when requesting an asset with the `debug: true` option.  So all assets had the query string param appended twice:

![double-body-query-string](https://user-images.githubusercontent.com/1121058/35761510-a0a696e4-0846-11e8-9710-d4f03870e1e2.png)

In my testing, this only seemed necessary for Rails 3, so I moved it to the rails 3 specific code.

**Broken Tests**
I noticed that [this commit](https://github.com/jasmine/jasmine-gem/commit/579dba66fc0fa374b8803566889ba679286d07bf#diff-f8451bed2fc3a84e4bb4ad706768d412) in 2014 seemed to have broken some of the rails asset pipeline specs.  I kept wondering why my debug code wasn't executing while trying to write a new spec and as it happens, there was no `yield` in `run_jasmine_server` block 😬.  So, any test that only had assertions within the `run_jasmine_server` block were passing as potential false positives.  

The test changes I have committed at this point are necessary to get the tests to pass after adding the `yield`.  With newer versions of rails, default is to always append asset digests now, which explains why I modified the regex to support the `.self-blahblahblah.js` format.

## Next Steps
I did verify all tests pass in rails 3/4/5, in addition to the manual tests I ran to get the screenshots above.

I'm happy to add in some tests for sprockets 4 if there's a chance this can be merged.  Are there any specific recommendations on how to do that, since the Gemfile would need to be customized for those specific tests?  If not, I can figure out a solution myself.

Thank you for your time and for reading this lengthy PR 🙇!