### PR TITLE
Chromeheadless

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 sudo: false
 cache: bundler
+addons:
+  chrome: stable
 
 rvm:
   - "2.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 sudo: false
 cache: bundler
+
 addons:
   chrome: stable
 
@@ -25,4 +26,11 @@ matrix:
 
 before_install:
   - gem update --system
-  - gem install bundler
+  - if [ "$RAILS_VERSION" == rails4 ];
+    then
+      find /home/travis/.rvm/rubies -wholename '*default/bundler-*.gemspec' -delete;
+      find /home/travis/.rvm/rubies -wholename '*bundler*.gemspec' -delete;
+      gem install bundler --version '<  2.0.0';
+    else
+      gem install bundler;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - "2.3"
   - "2.4"
   - "2.5"
+  - "2.6"
 
 env:
   - "RAILS_VERSION=rails5"

--- a/lib/jasmine.rb
+++ b/lib/jasmine.rb
@@ -18,6 +18,7 @@ jasmine_files = ['base',
                  File.join('formatters', 'console'),
                  File.join('formatters', 'multi'),
                  File.join('runners', 'phantom_js'),
+                 File.join('runners', 'chrome_headless'),
                 ]
 
 

--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -83,9 +83,7 @@ module Jasmine
       when :chromeheadless
         Jasmine::Runners::ChromeHeadless.new(formatter,
                                           jasmine_server_url,
-                                          @config.show_console_log,
-                                          @config.show_full_stack_trace,
-                                          @config.chrome_cli_options)
+                                          @config)
       else
         raise "Jasmine.config.runner_browser should be either phantomjs or chromeheadless"
       end

--- a/lib/jasmine/config.rb
+++ b/lib/jasmine/config.rb
@@ -71,13 +71,25 @@ module Jasmine
     end
 
     @config.runner = lambda do |formatter, jasmine_server_url|
-      Jasmine::Runners::PhantomJs.new(formatter,
-                                      jasmine_server_url,
-                                      @config.prevent_phantom_js_auto_install,
-                                      @config.show_console_log,
-                                      @config.phantom_config_script,
-                                      @config.show_full_stack_trace,
-                                      @config.phantom_cli_options)
+      case @config.runner_browser
+      when :phantomjs
+        Jasmine::Runners::PhantomJs.new(formatter,
+                                        jasmine_server_url,
+                                        @config.prevent_phantom_js_auto_install,
+                                        @config.show_console_log,
+                                        @config.phantom_config_script,
+                                        @config.show_full_stack_trace,
+                                        @config.phantom_cli_options)
+      when :chromeheadless
+        Jasmine::Runners::ChromeHeadless.new(formatter,
+                                          jasmine_server_url,
+                                          @config.show_console_log,
+                                          @config.show_full_stack_trace,
+                                          @config.chrome_cli_options)
+      else
+        raise "Jasmine.config.runner_browser should be either phantomjs or chromeheadless"
+      end
+
     end
   end
 

--- a/lib/jasmine/configuration.rb
+++ b/lib/jasmine/configuration.rb
@@ -17,7 +17,9 @@ module Jasmine
     attr_accessor :random
     attr_accessor :phantom_config_script
     attr_accessor :phantom_cli_options
+    attr_accessor :chrome_cli_options
     attr_accessor :show_full_stack_trace
+    attr_accessor :runner_browser
     attr_reader :rack_apps
 
     def initialize()
@@ -41,6 +43,8 @@ module Jasmine
       @random = true
       @phantom_config_script = nil
       @phantom_cli_options = {}
+      @chrome_cli_options = {}
+      @runner_browser = :phantomjs
 
       @formatters = [Jasmine::Formatters::Console]
 

--- a/lib/jasmine/configuration.rb
+++ b/lib/jasmine/configuration.rb
@@ -19,6 +19,7 @@ module Jasmine
     attr_accessor :phantom_cli_options
     attr_accessor :chrome_cli_options
     attr_accessor :chrome_startup_timeout
+    attr_accessor :chrome_binary
     attr_accessor :show_full_stack_trace
     attr_accessor :runner_browser
     attr_reader :rack_apps
@@ -46,6 +47,7 @@ module Jasmine
       @phantom_cli_options = {}
       @chrome_cli_options = {}
       @chrome_startup_timeout = 3
+      @chrome_binary = nil
       @runner_browser = :phantomjs
 
       @formatters = [Jasmine::Formatters::Console]

--- a/lib/jasmine/configuration.rb
+++ b/lib/jasmine/configuration.rb
@@ -18,6 +18,7 @@ module Jasmine
     attr_accessor :phantom_config_script
     attr_accessor :phantom_cli_options
     attr_accessor :chrome_cli_options
+    attr_accessor :chrome_startup_timeout
     attr_accessor :show_full_stack_trace
     attr_accessor :runner_browser
     attr_reader :rack_apps
@@ -44,6 +45,7 @@ module Jasmine
       @phantom_config_script = nil
       @phantom_cli_options = {}
       @chrome_cli_options = {}
+      @chrome_startup_timeout = 3
       @runner_browser = :phantomjs
 
       @formatters = [Jasmine::Formatters::Console]

--- a/lib/jasmine/configuration.rb
+++ b/lib/jasmine/configuration.rb
@@ -45,7 +45,7 @@ module Jasmine
       @random = true
       @phantom_config_script = nil
       @phantom_cli_options = {}
-      @chrome_cli_options = {}
+      @chrome_cli_options = {"no-sandbox" => nil, "headless" => nil, "remote-debugging-port" => 9222}
       @chrome_startup_timeout = 3
       @chrome_binary = nil
       @runner_browser = :phantomjs

--- a/lib/jasmine/runners/chrome_headless.rb
+++ b/lib/jasmine/runners/chrome_headless.rb
@@ -14,7 +14,7 @@ module Jasmine
       end
 
       def run
-        chrome_server = IO.popen("\"#{find_chrome_binary}\" --no-sandbox --headless --remote-debugging-port=9222 #{cli_options_string}")
+        chrome_server = IO.popen("\"#{chrome_binary}\" --no-sandbox --headless --remote-debugging-port=9222 #{cli_options_string}")
         wait_for_chrome_to_start_debug_socket
 
         begin
@@ -54,6 +54,10 @@ module Jasmine
         formatter.done(run_details)
         chrome.send_cmd "Browser.close"
         Process.kill("INT", chrome_server.pid)
+      end
+
+      def chrome_binary
+        config.chrome_binary || find_chrome_binary
       end
 
       def find_chrome_binary

--- a/lib/jasmine/runners/chrome_headless.rb
+++ b/lib/jasmine/runners/chrome_headless.rb
@@ -85,6 +85,9 @@ module Jasmine
           rescue SocketError;
             sleep 0.1
             next
+          rescue Errno::ECONNREFUSED;
+            sleep 0.1
+            next
           rescue Errno::EADDRNOTAVAIL;
             sleep 0.1
             next

--- a/lib/jasmine/runners/chrome_headless.rb
+++ b/lib/jasmine/runners/chrome_headless.rb
@@ -14,7 +14,7 @@ module Jasmine
       end
 
       def run
-        chrome_server = IO.popen("\"#{chrome_binary}\" --no-sandbox --headless --remote-debugging-port=9222 #{cli_options_string}")
+        chrome_server = IO.popen("\"#{chrome_binary}\" #{cli_options_string}")
         wait_for_chrome_to_start_debug_socket
 
         begin
@@ -73,7 +73,7 @@ module Jasmine
 
       def cli_options_string
         @cli_options.
-            map {|(k, v)| "--#{k}=#{v}"}.
+            map {|(k, v)| if v then "--#{k}=#{v}" else "--#{k}" end }.
             join(' ')
       end
 

--- a/lib/jasmine/runners/chromeheadless_boot.js
+++ b/lib/jasmine/runners/chromeheadless_boot.js
@@ -1,0 +1,15 @@
+function ChromeHeadlessReporter() {
+  this.jasmineDone = function(details) {
+    console.log('jasmine_done', JSON.stringify(details));
+  };
+
+  this.specDone = function(results) {
+    console.log('jasmine_spec_result', JSON.stringify([].concat(results)));
+  };
+
+  this.suiteDone = function(results) {
+    console.log('jasmine_suite_result',JSON.stringify([].concat(results)));
+  };
+}
+
+jasmine.getEnv().addReporter(new ChromeHeadlessReporter());

--- a/spec/chrome_headless_spec.rb
+++ b/spec/chrome_headless_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Jasmine::Runners::ChromeHeadless do
+
+  let(:config) {
+    {
+      show_console_log: nil,
+      show_full_stack_trace: nil,
+      chrome_cli_options: nil,
+      chrome_binary: nil,
+    }
+  }
+
+  it 'uses chrome_binary from config is set' do
+    config[:chrome_binary] = "some_path"
+    runner = Jasmine::Runners::ChromeHeadless.new(nil, nil, double(config))
+
+    expect(runner.chrome_binary).to eq("some_path")
+  end
+
+  it 'uses chrome_binary from default chrome path if it exist' do
+    allow(File).to receive(:file?).and_return(true)
+    runner = Jasmine::Runners::ChromeHeadless.new(nil, nil, double(config))
+
+    expect(runner.chrome_binary).to eq("/usr/bin/google-chrome")
+  end
+
+  it 'chrome_binary raise an exeption if nowhere to be found' do
+    allow(File).to receive(:file?).and_return(false)
+    runner = Jasmine::Runners::ChromeHeadless.new(nil, nil, double(config))
+
+    expect {
+      runner.chrome_binary
+    }.to raise_error(RuntimeError)
+  end
+
+  describe "cli_options_string" do
+    it "empty hash is empty result" do
+      runner = Jasmine::Runners::ChromeHeadless.new(nil, nil, double(config))
+      expect(runner.cli_options_string).to eq("")
+    end
+
+    it "formats hash properly" do
+      config[:chrome_cli_options] = {"no-sandbox" => nil, "headless" => nil, "remote-debugging-port" => 9222}
+      runner = Jasmine::Runners::ChromeHeadless.new(nil, nil, double(config))
+      expect(runner.cli_options_string).to eq("--no-sandbox --headless --remote-debugging-port=9222")
+    end
+  end
+
+end


### PR DESCRIPTION
close #293 

I added a Chrome headless runner. I tries to add it without adding any other run depenecies at installation. "chrome_remote" is a gem I require at runtime if you use chrome headless.

I left the default at :phanthonJS
We will start to run our CI jobs on chrome today. I want to start the process of getting this meged.