### PR TITLE
Support Rails 6

### DIFF
--- a/lib/jasmine/asset_expander.rb
+++ b/lib/jasmine/asset_expander.rb
@@ -13,11 +13,11 @@ module Jasmine
     UnsupportedRailsVersion = Class.new(StandardError)
 
     def asset_bundle
-      return Rails4Or5AssetBundle.new if Jasmine::Dependencies.rails4? || Jasmine::Dependencies.rails5?
-      raise UnsupportedRailsVersion, "Jasmine only supports the asset pipeline for Rails 4. - 5"
+      return Rails4Or5Or6AssetBundle.new if Jasmine::Dependencies.rails4? || Jasmine::Dependencies.rails5? || Jasmine::Dependencies.rails6?
+      raise UnsupportedRailsVersion, "Jasmine only supports the asset pipeline for Rails 4. - 6"
     end
 
-    class Rails4Or5AssetBundle
+    class Rails4Or5Or6AssetBundle
       def assets(pathname)
         if pathname =~ /\.css$/
           context.get_stylesheet_assets(pathname.gsub(/\.css$/, ''))

--- a/lib/jasmine/dependencies.rb
+++ b/lib/jasmine/dependencies.rb
@@ -10,12 +10,16 @@ module Jasmine
         rails? && Rails.version.to_i == 5
       end
 
+      def rails6?
+        rails? && Rails.version.to_i == 6
+      end
+
       def rails?
         defined?(Rails) && Rails.respond_to?(:version)
       end
 
       def use_asset_pipeline?
-        (rails4? || rails5?) &&
+        (rails4? || rails5? || rails6?) &&
           Rails.respond_to?(:application) &&
           Rails.application.respond_to?(:assets) &&
           !Rails.application.assets.nil?

--- a/lib/jasmine/dependencies.rb
+++ b/lib/jasmine/dependencies.rb
@@ -15,8 +15,10 @@ module Jasmine
       end
 
       def use_asset_pipeline?
-        assets_pipeline_available = (rails4? || rails5?) && Rails.respond_to?(:application) && Rails.application.respond_to?(:assets) && !Rails.application.assets.nil?
-        assets_pipeline_available && (rails4? || rails5?)
+        (rails4? || rails5?) &&
+          Rails.respond_to?(:application) &&
+          Rails.application.respond_to?(:assets) &&
+          !Rails.application.assets.nil?
       end
     end
   end


### PR DESCRIPTION
There are some possible changes with how assets can be handled with
Rails 6, but upgrading without any other changes doesn't prevent the
existing code in Jasmine from working fine, so update the
AssetExpander to allow Jasmine to continue to work with Rails 6.