### PR TITLE
Add an option to disable colored output

### DIFF
--- a/lib/jasmine/formatters/console.rb
+++ b/lib/jasmine/formatters/console.rb
@@ -1,6 +1,18 @@
 module Jasmine
   module Formatters
     class Console
+      def self.color_enabled=(value)
+        @color_enabled = value
+      end
+
+      def self.color_enabled
+        if instance_variable_defined?(:@color_enabled)
+          @color_enabled
+        else
+          !ENV["NO_COLOR"]
+        end
+      end
+
       def initialize(outputter = Kernel)
         @results = []
         @outputter = outputter
@@ -143,7 +155,11 @@ module Jasmine
               "\e[0m"
             end
 
-        "#{s}#{message}\e[0m"
+        if self.class.color_enabled
+          "#{s}#{message}\e[0m"
+        else
+          message
+        end
       end
     end
   end

--- a/lib/jasmine/formatters/console.rb
+++ b/lib/jasmine/formatters/console.rb
@@ -91,13 +91,13 @@ module Jasmine
       def chars(results)
         results.map do |result|
           if result.succeeded?
-            "\e[32m.\e[0m"
+            colored(:green, '.')
           elsif result.pending?
-            "\e[33m*\e[0m"
+            colored(:yellow, '*')
           elsif result.disabled?
             ""
           else
-            "\e[31mF\e[0m"
+            colored(:red, 'F')
           end
         end.join('')
       end
@@ -111,7 +111,7 @@ module Jasmine
         reason = 'No reason given'
         reason = spec.pending_reason if spec.pending_reason && spec.pending_reason != ''
 
-        "\t#{spec.full_name}\n\t  \e[33m#{reason}\e[0m"
+        "\t#{spec.full_name}\n\t  #{colored(:yellow, reason)}"
       end
 
       def failure_message(failure)
@@ -121,7 +121,7 @@ module Jasmine
       def expectation_message(expectation)
         <<-FE
   Message:
-      \e[31m#{expectation.message}\e[0m
+      #{colored(:red, expectation.message)}
   Stack:
       #{stack(expectation.stack)}
         FE
@@ -129,6 +129,21 @@ module Jasmine
 
       def stack(stack)
         stack.split("\n").map(&:strip).join("\n      ")
+      end
+
+      def colored(color, message)
+        s = case color
+            when :green
+              "\e[32m"
+            when :yellow
+              "\e[33m"
+            when :red
+              "\e[31m"
+            else
+              "\e[0m"
+            end
+
+        "#{s}#{message}\e[0m"
       end
     end
   end


### PR DESCRIPTION
I'd like to propose an option to disable coloring outputs. This should be useful for CI environments because they usually don't handle color escape sequences well.

- `Jasmine::Formatters::Console.color_enabled=` allows enable/disable coloring outputs.
- It also supports [`NO_COLOR`](https://no-color.org/) environment variable so that users can disable coloring without changing their test code.