### PR TITLE
Add support for chrome from yaourt

### DIFF
--- a/lib/jasmine/runners/chrome_headless.rb
+++ b/lib/jasmine/runners/chrome_headless.rb
@@ -63,6 +63,7 @@ module Jasmine
       def find_chrome_binary
         path = [
           "/usr/bin/google-chrome",
+          "/usr/bin/google-chrome-stable",
           "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
         ].detect { |path|
           File.file?(path)
@@ -108,4 +109,3 @@ module Jasmine
     end
   end
 end
-


### PR DESCRIPTION
This small fix adds support for yaourt chrome
https://aur.archlinux.org/packages/google-chrome/