### PR TITLE
Fix Action View deprecation warnings in Rails 6

### DIFF
--- a/lib/jasmine/asset_expander.rb
+++ b/lib/jasmine/asset_expander.rb
@@ -29,7 +29,23 @@ module Jasmine
       private
 
       def context
-        @context ||= ActionView::Base.new.extend(GetOriginalAssetsHelper)
+        @context ||= template.extend(GetOriginalAssetsHelper)
+      end
+
+      def controller_class
+        Class.new(ActionController::Base)
+      end
+
+      def controller
+        controller_class.new
+      end
+
+      def lookup_context
+        ActionView::LookupContext.new([])
+      end
+
+      def template
+        ActionView::Base.new(lookup_context, {}, controller)
       end
 
       module GetOriginalAssetsHelper


### PR DESCRIPTION
In a future version of Rails, ActionView::Base#initialize will no longer have default values for the first three arguments of lookup_context, assignments and controller. To fix this create the instance by using a ActionView::LookupContext with an empty view path set, an empty assignment hash and a controller using an anonymous controller class.